### PR TITLE
Daniel Strauss/101/Set rule/setting to treat warnings as compile error

### DIFF
--- a/backend/ContainerApp/Directory.Build.props
+++ b/backend/ContainerApp/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Set the rule in the file name Directory.Build.props
Try to add code with a warning and get an error 