### PR TITLE
Improve message lock renewal logic and cleanup logging

### DIFF
--- a/backend/ContainerApp/Engine/Endpoints/EngineQueueHandler.cs
+++ b/backend/ContainerApp/Engine/Endpoints/EngineQueueHandler.cs
@@ -63,14 +63,12 @@ public class EngineQueueHandler : IQueueHandler<Message>
                 while (!renewalCts.Token.IsCancellationRequested)
                 {
                     await Task.Delay(TimeSpan.FromSeconds(20), renewalCts.Token);
-                    _logger.LogDebug("Renewing lock at {Now}", DateTime.UtcNow);
                     await renewLock();
-                    _logger.LogDebug("Lock renewed at {Now}", DateTime.UtcNow);
                 }
             }
             catch (OperationCanceledException)
             {
-                // expected
+                throw;
             }
         }, renewalCts.Token);
         try
@@ -97,16 +95,6 @@ public class EngineQueueHandler : IQueueHandler<Message>
             await renewalCts.CancelAsync();
             await renewalTask;
         }
-        //That is simple example of how to use renewLock to prevent exciding message lock time 
-        //_logger.LogInformation("Inside handler");
-        //await renewLock();
-        //await Task.Delay(TimeSpan.FromSeconds(50), cancellationToken);
-        //_logger.LogInformation("After first pause");
-        //await renewLock();
-        //await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
-        //_logger.LogInformation("Processing task {Id}", payload.Id);
-        //await _engine.ProcessTaskAsync(payload, cancellationToken);
-        //_logger.LogInformation("Task {Id} processed", payload.Id);
     }
 }
 

--- a/backend/ContainerApp/Engine/Messaging/AzureServiceBusQueueListener.cs
+++ b/backend/ContainerApp/Engine/Messaging/AzureServiceBusQueueListener.cs
@@ -35,19 +35,31 @@ public class AzureServiceBusQueueListener<T> : IQueueListener<T>, IAsyncDisposab
 
         _processor.ProcessMessageAsync += async args =>
         {
-            var now = DateTimeOffset.UtcNow;
-            var lockedUntil = args.Message.LockedUntil;
-            var lockTimeout = lockedUntil - now;
-
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            linkedCts.CancelAfter(lockTimeout);
+
+            void ArmCancelAfterFromLockedUntil()
+            {
+                var now = DateTimeOffset.UtcNow;
+                var timeout = args.Message.LockedUntil - now - TimeSpan.FromSeconds(2);
+                if (timeout <= TimeSpan.Zero)
+                {
+                    linkedCts.Cancel();
+                }
+                else
+                {
+                    linkedCts.CancelAfter(timeout);
+                }
+            }
+
+            ArmCancelAfterFromLockedUntil();
 
             var renewLock = async () =>
             {
-                _logger.LogInformation("Lock till: {Time}", args.Message.LockedUntil);
                 await args.RenewMessageLockAsync(args.Message, linkedCts.Token);
                 _logger.LogDebug("Lock renewed for message {MessageId}", args.Message.MessageId);
-                _logger.LogInformation("Lock till: {Time}", args.Message.LockedUntil);
+                _logger.LogDebug("Lock till: {Time}", args.Message.LockedUntil);
+
+                ArmCancelAfterFromLockedUntil();
             };
 
             try


### PR DESCRIPTION
Refactored lock renewal in AzureServiceBusQueueListener to more accurately set cancellation based on message lock expiration, including a safety buffer. Removed redundant and commented-out logging in EngineQueueHandler and changed OperationCanceledException handling to rethrow for better error propagation.