### PR TITLE
Fix Service Bus emulator “queue not found” startup errors

### DIFF
--- a/backend/ContainerApp/Accessor/Messaging/ServiceCollectionExtensions.cs
+++ b/backend/ContainerApp/Accessor/Messaging/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
 
 namespace Accessor.Messaging;
 
@@ -20,6 +21,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IQueueListener<T>>(sp =>
             new AzureServiceBusQueueListener<T>(
                 sp.GetRequiredService<ServiceBusClient>(),
+                sp.GetRequiredService<ServiceBusAdministrationClient>(),
                 queueName,
                 settings,
                 sp.GetRequiredService<IRetryPolicyProvider>(),

--- a/backend/ContainerApp/Accessor/appsettings.json
+++ b/backend/ContainerApp/Accessor/appsettings.json
@@ -15,6 +15,6 @@
     "Postgres": "Host=postgres;Port=5432;Database=postgres_db;Username=postgres;Password=postgres"
   },
   "ServiceBus": {
-    "ConnectionString": "Endpoint=sb://sbemulatorns:5672/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
+    "ConnectionString": "Endpoint=sb://sbemulatorns/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
   }
 }

--- a/backend/ContainerApp/Engine/Messaging/AzureServiceBusQueueListener.cs
+++ b/backend/ContainerApp/Engine/Messaging/AzureServiceBusQueueListener.cs
@@ -1,22 +1,33 @@
 ﻿using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
 using System.Text.Json;
 
 namespace Engine.Messaging;
 
 public class AzureServiceBusQueueListener<T> : IQueueListener<T>, IAsyncDisposable
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
     private readonly ServiceBusProcessor _processor;
+    private readonly ServiceBusAdministrationClient _admin;
+    private readonly string _queueName;
     private readonly IRetryPolicyProvider _retryPolicyProvider;
     private readonly QueueSettings _settings;
     private readonly ILogger<AzureServiceBusQueueListener<T>> _logger;
 
     public AzureServiceBusQueueListener(
         ServiceBusClient client,
+        ServiceBusAdministrationClient admin,
         string queueName,
         QueueSettings settings,
         IRetryPolicyProvider retryPolicyProvider,
         ILogger<AzureServiceBusQueueListener<T>> logger)
     {
+        _admin = admin;
+        _queueName = queueName;
         _settings = settings;
         _retryPolicyProvider = retryPolicyProvider;
         _logger = logger;
@@ -31,50 +42,61 @@ public class AzureServiceBusQueueListener<T> : IQueueListener<T>, IAsyncDisposab
 
     public async Task StartAsync(Func<T, Func<Task>, CancellationToken, Task> handler, CancellationToken cancellationToken)
     {
+        // Wait for emulator to finish creating the queue
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(60);
+        var delay = TimeSpan.FromMilliseconds(500);
+
+        while (DateTimeOffset.UtcNow < deadline && !cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (await _admin.QueueExistsAsync(_queueName, cancellationToken))
+                {
+                    _logger.LogInformation("Queue '{Queue}' is available.", _queueName);
+                    break;
+                }
+
+                _logger.LogInformation("Queue '{Queue}' not ready yet. Waiting...", _queueName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Queue existence check failed; retrying.");
+            }
+
+            await Task.Delay(delay, cancellationToken);
+            if (delay < TimeSpan.FromSeconds(5))
+            {
+                delay += delay; // simple backoff
+            }
+        }
+
         var retryPolicy = _retryPolicyProvider.Create(_settings, _logger);
 
         _processor.ProcessMessageAsync += async args =>
         {
+            var lockTimeout = args.Message.LockedUntil - DateTimeOffset.UtcNow;
+
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-
-            void ArmCancelAfterFromLockedUntil()
+            if (lockTimeout > TimeSpan.Zero)
             {
-                var now = DateTimeOffset.UtcNow;
-                var timeout = args.Message.LockedUntil - now - TimeSpan.FromSeconds(2);
-                if (timeout <= TimeSpan.Zero)
-                {
-                    linkedCts.Cancel();
-                }
-                else
-                {
-                    linkedCts.CancelAfter(timeout);
-                }
+                linkedCts.CancelAfter(lockTimeout);
             }
-
-            ArmCancelAfterFromLockedUntil();
 
             var renewLock = async () =>
             {
                 await args.RenewMessageLockAsync(args.Message, linkedCts.Token);
                 _logger.LogDebug("Lock renewed for message {MessageId}", args.Message.MessageId);
-                _logger.LogDebug("Lock till: {Time}", args.Message.LockedUntil);
-
-                ArmCancelAfterFromLockedUntil();
             };
 
             try
             {
                 var json = args.Message.Body.ToString();
                 _logger.LogDebug("Raw message body: {Json}", json);
-                var jsonOptions = new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true,
-                };
-                var msg = JsonSerializer.Deserialize<T>(json, jsonOptions);
 
+                var msg = JsonSerializer.Deserialize<T>(json, JsonOptions);
                 if (msg == null)
                 {
-                    _logger.LogWarning("Failed to deserialize message.");
+                    _logger.LogWarning("Failed to deserialize message, dead-lettering.");
                     await args.DeadLetterMessageAsync(args.Message, cancellationToken: cancellationToken);
                     return;
                 }
@@ -128,4 +150,3 @@ public class AzureServiceBusQueueListener<T> : IQueueListener<T>, IAsyncDisposab
         GC.SuppressFinalize(this);
     }
 }
-

--- a/backend/ContainerApp/Engine/Messaging/ServiceCollectionExtensions.cs
+++ b/backend/ContainerApp/Engine/Messaging/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
 
 namespace Engine.Messaging;
 
@@ -20,6 +21,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IQueueListener<T>>(sp =>
             new AzureServiceBusQueueListener<T>(
                 sp.GetRequiredService<ServiceBusClient>(),
+                sp.GetRequiredService<ServiceBusAdministrationClient>(),
                 queueName,
                 settings,
                 sp.GetRequiredService<IRetryPolicyProvider>(),

--- a/backend/ContainerApp/Engine/appsettings.Development.json
+++ b/backend/ContainerApp/Engine/appsettings.Development.json
@@ -20,6 +20,6 @@
     "TimeoutSeconds": 70
   },
   "ServiceBus": {
-    "ConnectionString": "Endpoint=sb://sbemulatorns:5672/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
+    "ConnectionString": "Endpoint=sb://sbemulatorns/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
   }
 }

--- a/backend/ContainerApp/Engine/appsettings.json
+++ b/backend/ContainerApp/Engine/appsettings.json
@@ -26,7 +26,7 @@
   },
 
   "ServiceBus": {
-    "ConnectionString": "Endpoint=sb://sbemulatorns:5672/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
+    "ConnectionString": "Endpoint=sb://sbemulatorns/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
   }
 
 }

--- a/backend/ContainerApp/Manager/Messaging/AzureServiceBusQueueListener.cs
+++ b/backend/ContainerApp/Manager/Messaging/AzureServiceBusQueueListener.cs
@@ -1,22 +1,33 @@
 ﻿using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
 using System.Text.Json;
 
 namespace Manager.Messaging;
 
 public class AzureServiceBusQueueListener<T> : IQueueListener<T>, IAsyncDisposable
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
     private readonly ServiceBusProcessor _processor;
+    private readonly ServiceBusAdministrationClient _admin;
+    private readonly string _queueName;
     private readonly IRetryPolicyProvider _retryPolicyProvider;
     private readonly QueueSettings _settings;
     private readonly ILogger<AzureServiceBusQueueListener<T>> _logger;
 
     public AzureServiceBusQueueListener(
         ServiceBusClient client,
+        ServiceBusAdministrationClient admin,
         string queueName,
         QueueSettings settings,
         IRetryPolicyProvider retryPolicyProvider,
         ILogger<AzureServiceBusQueueListener<T>> logger)
     {
+        _admin = admin;
+        _queueName = queueName;
         _settings = settings;
         _retryPolicyProvider = retryPolicyProvider;
         _logger = logger;
@@ -31,16 +42,45 @@ public class AzureServiceBusQueueListener<T> : IQueueListener<T>, IAsyncDisposab
 
     public async Task StartAsync(Func<T, Func<Task>, CancellationToken, Task> handler, CancellationToken cancellationToken)
     {
+        // Wait for the emulator to finish creating the queue
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(60);
+        var delay = TimeSpan.FromMilliseconds(500);
+
+        while (DateTimeOffset.UtcNow < deadline && !cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (await _admin.QueueExistsAsync(_queueName, cancellationToken))
+                {
+                    _logger.LogInformation("Queue '{Queue}' is available.", _queueName);
+                    break;
+                }
+
+                _logger.LogInformation("Queue '{Queue}' not ready yet. Waiting...", _queueName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Queue existence check failed; retrying.");
+            }
+
+            await Task.Delay(delay, cancellationToken);
+            if (delay < TimeSpan.FromSeconds(5))
+            {
+                delay += delay; // simple backoff
+            }
+        }
+
         var retryPolicy = _retryPolicyProvider.Create(_settings, _logger);
 
         _processor.ProcessMessageAsync += async args =>
         {
-            var now = DateTimeOffset.UtcNow;
-            var lockedUntil = args.Message.LockedUntil;
-            var lockTimeout = lockedUntil - now;
+            var lockTimeout = args.Message.LockedUntil - DateTimeOffset.UtcNow;
 
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            linkedCts.CancelAfter(lockTimeout);
+            if (lockTimeout > TimeSpan.Zero)
+            {
+                linkedCts.CancelAfter(lockTimeout);
+            }
 
             var renewLock = async () =>
             {
@@ -52,15 +92,11 @@ public class AzureServiceBusQueueListener<T> : IQueueListener<T>, IAsyncDisposab
             {
                 var json = args.Message.Body.ToString();
                 _logger.LogDebug("Raw message body: {Json}", json);
-                var jsonOptions = new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true,
-                };
-                var msg = JsonSerializer.Deserialize<T>(json, jsonOptions);
 
+                var msg = JsonSerializer.Deserialize<T>(json, JsonOptions);
                 if (msg == null)
                 {
-                    _logger.LogWarning("Failed to deserialize message.");
+                    _logger.LogWarning("Failed to deserialize message, dead-lettering.");
                     await args.DeadLetterMessageAsync(args.Message, cancellationToken: cancellationToken);
                     return;
                 }
@@ -114,4 +150,3 @@ public class AzureServiceBusQueueListener<T> : IQueueListener<T>, IAsyncDisposab
         GC.SuppressFinalize(this);
     }
 }
-

--- a/backend/ContainerApp/Manager/Messaging/ServiceCollectionExtensions.cs
+++ b/backend/ContainerApp/Manager/Messaging/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
 
 namespace Manager.Messaging;
 
@@ -20,6 +21,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IQueueListener<T>>(sp =>
             new AzureServiceBusQueueListener<T>(
                 sp.GetRequiredService<ServiceBusClient>(),
+                sp.GetRequiredService<ServiceBusAdministrationClient>(),
                 queueName,
                 settings,
                 sp.GetRequiredService<IRetryPolicyProvider>(),

--- a/backend/ContainerApp/Manager/appsettings.json
+++ b/backend/ContainerApp/Manager/appsettings.json
@@ -14,7 +14,7 @@
     "DefaultTtlSeconds": 60
   },
   "ServiceBus": {
-    "ConnectionString": "Endpoint=sb://sbemulatorns:5672/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
+    "ConnectionString": "Endpoint=sb://sbemulatorns/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
   },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
Our services (Manager/Engine/Accessor) started listening immediately at boot.
The Service Bus emulator was still starting and then creating the queues from UserConfig a few seconds later.
During that gap, the SDK tried to open a receiver on queues that didn’t exist yet → MessagingEntityNotFound (and sometimes ConnectionRefused while the emulator was still coming up).

Root cause:
Startup race condition between our consumers and the emulator’s entity creation.
Even with depends_on and container healthchecks, the emulator marks itself “up” before it has finished creating all queues/topics.

What we changed:

1. Added an admin client so we can ask the namespace whether the queue exists:
// admin client used only to *wait* for the queue to exist
builder.Services.AddSingleton(sp =>
{
    var cfg = sp.GetRequiredService<IConfiguration>();
    var cs = cfg["ServiceBus:ConnectionString"] ?? cfg.GetConnectionString("ServiceBus");
    return new ServiceBusAdministrationClient(cs!);
});

2. Taught the queue listeners to wait until the queue is present before starting the processor:

- Injected and stored:

private readonly ServiceBusAdministrationClient _admin;
private readonly string _queueName;
In StartAsync, added a small retry/backoff loop:

// Pseudocode: wait up to ~60s
while (!cancellationToken.IsCancellationRequested && !await _admin.QueueExistsAsync(_queueName))
{
    _logger.LogInformation("Queue '{Queue}' not ready yet. Waiting...", _queueName);
    await Task.Delay(delay, cancellationToken);
    delay = TimeSpan.FromMilliseconds(Math.Min(delay.TotalMilliseconds * 2, 5000)); // simple backoff
}

// Only now start the processor
await _processor.StartProcessingAsync(cancellationToken);

- DI wiring: updated registration so the listener receives the admin client:

// in ServiceCollectionExtensions.AddQueue(...)
new AzureServiceBusQueueListener<T>(
    sp.GetRequiredService<ServiceBusClient>(),
    sp.GetRequiredService<ServiceBusAdministrationClient>(), // <-- added
    queueName,
    settings,
    sp.GetRequiredService<IRetryPolicyProvider>(),
    sp.GetRequiredService<ILogger<AzureServiceBusQueueListener<T>>>())

The listener won’t call CreateProcessor(...).StartProcessingAsync() until the queue truly exists.
That removes the race with the emulator’s entity creation and eliminates the MessagingEntityNotFound errors.