### PR TITLE
ouriel/287//add-Use-ttl-and-cancellationtoken-in-azurespeechsynthesisservice

### DIFF
--- a/backend/ContainerApp/Engine/Endpoints/AiEndpoints.cs
+++ b/backend/ContainerApp/Engine/Endpoints/AiEndpoints.cs
@@ -121,6 +121,16 @@ public static class AiEndpoints
                 return Results.Problem("Speech synthesis failed.");
             }
         }
+        catch (OperationCanceledException)
+        {
+            logger.LogWarning("Speech synthesis operation was canceled by user");
+            return Results.StatusCode(StatusCodes.Status499ClientClosedRequest);
+        }
+        catch (TimeoutException)
+        {
+            logger.LogWarning("Speech synthesis operation timed out");
+            return Results.StatusCode(StatusCodes.Status408RequestTimeout);
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Error during speech synthesis");

--- a/backend/ContainerApp/Engine/Models/Speech/AzureSpeechSettings.cs
+++ b/backend/ContainerApp/Engine/Models/Speech/AzureSpeechSettings.cs
@@ -9,5 +9,6 @@ public record AzureSpeechSettings
     public required string Region { get; set; } = string.Empty;
 
     public string DefaultVoice { get; set; } = "he-IL-HilaNeural";
+
     public int TimeoutSeconds { get; set; } = 30;
 }

--- a/backend/ContainerApp/Manager/Endpoints/AiEndpoints.cs
+++ b/backend/ContainerApp/Manager/Endpoints/AiEndpoints.cs
@@ -182,6 +182,16 @@ public static class AiEndpoints
                 return Results.Problem("Speech synthesis failed.");
             }
         }
+        catch (OperationCanceledException)
+        {
+            logger.LogWarning("Speech synthesis operation was canceled by user");
+            return Results.StatusCode(StatusCodes.Status499ClientClosedRequest);
+        }
+        catch (TimeoutException)
+        {
+            logger.LogWarning("Speech synthesis operation timed out");
+            return Results.Problem("Speech is too long.", statusCode: StatusCodes.Status408RequestTimeout);
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Error in speech synthesis manager");

--- a/backend/ContainerApp/Manager/Services/Clients/Engine/EngineClient.cs
+++ b/backend/ContainerApp/Manager/Services/Clients/Engine/EngineClient.cs
@@ -75,6 +75,16 @@ public class EngineClient : IEngineClient
 
             return result;
         }
+        catch (InvocationException ex) when (ex.InnerException is HttpRequestException httpEx && httpEx.Message.Contains("408"))
+        {
+            _logger.LogWarning("Speech synthesis request timed out (408)");
+            throw new TimeoutException("Speech synthesis request timed out", ex);
+        }
+        catch (InvocationException ex) when (ex.InnerException is HttpRequestException httpEx && httpEx.Message.Contains("499"))
+        {
+            _logger.LogWarning("Speech synthesis request was canceled by client (499)");
+            throw new OperationCanceledException("Speech synthesis request was canceled by client", ex);
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error communicating with speech engine");


### PR DESCRIPTION
changed speech synthesizer in engine to use cancellation token combined with TTL when calling Azure TTS 
Improved HTTP response handling for the client