### PR TITLE
Snir/dapr observability options

### DIFF
--- a/devops/helm-tools/prometheus/dashboards/dapr-metrics.json
+++ b/devops/helm-tools/prometheus/dashboards/dapr-metrics.json
@@ -190,7 +190,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(dapr_http_server_request_duration_ms_bucket{kubernetes_namespace=~\"$namespace\"}[5m])) by (le, dapr_app_id))",
+          "expr": "histogram_quantile(0.95, sum(rate(dapr_http_server_latency_bucket{kubernetes_namespace=~\"$namespace\"}[5m])) by (le, dapr_app_id))",
           "interval": "",
           "legendFormat": "{{dapr_app_id}} - 95th percentile",
           "refId": "A"
@@ -200,7 +200,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(dapr_http_server_request_duration_ms_bucket{kubernetes_namespace=~\"$namespace\"}[5m])) by (le, dapr_app_id))",
+          "expr": "histogram_quantile(0.50, sum(rate(dapr_http_server_latency_bucket{kubernetes_namespace=~\"$namespace\"}[5m])) by (le, dapr_app_id))",
           "interval": "",
           "legendFormat": "{{dapr_app_id}} - 50th percentile",
           "refId": "B"
@@ -288,10 +288,20 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dapr_component_invocation_count{kubernetes_namespace=~\"$namespace\"}[5m])) by (dapr_app_id, component)",
+          "expr": "sum(rate(dapr_component_output_binding_count{kubernetes_namespace=~\"$namespace\"}[5m])) by (dapr_app_id, component)",
           "interval": "",
-          "legendFormat": "{{dapr_app_id}} - {{component}}",
+          "legendFormat": "{{dapr_app_id}} - {{component}} (out)",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dapr_component_input_binding_count{kubernetes_namespace=~\"$namespace\"}[5m])) by (dapr_app_id, component)",
+          "interval": "",
+          "legendFormat": "{{dapr_app_id}} - {{component}} (in)",
+          "refId": "B"
         }
       ],
       "title": "Dapr Component Invocations (Service Bus, State Store)",
@@ -376,7 +386,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(dapr_service_invocation_req_sent_total{kubernetes_namespace=~\"$namespace\"}[5m])) by (dapr_app_id, target_app_id)",
+          "expr": "sum(rate(dapr_runtime_service_invocation_req_sent_total{kubernetes_namespace=~\"$namespace\"}[5m])) by (dapr_app_id, target_app_id)",
           "interval": "",
           "legendFormat": "{{dapr_app_id}} → {{target_app_id}}",
           "refId": "A"

--- a/devops/helm-tools/prometheus/dashboards/dapr-metrics.json
+++ b/devops/helm-tools/prometheus/dashboards/dapr-metrics.json
@@ -1,0 +1,518 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dapr_http_server_request_count{kubernetes_namespace=~\"$namespace\"}[5m])) by (dapr_app_id)",
+          "interval": "",
+          "legendFormat": "{{dapr_app_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Dapr HTTP Requests Rate (req/sec)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(dapr_http_server_request_duration_ms_bucket{kubernetes_namespace=~\"$namespace\"}[5m])) by (le, dapr_app_id))",
+          "interval": "",
+          "legendFormat": "{{dapr_app_id}} - 95th percentile",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(dapr_http_server_request_duration_ms_bucket{kubernetes_namespace=~\"$namespace\"}[5m])) by (le, dapr_app_id))",
+          "interval": "",
+          "legendFormat": "{{dapr_app_id}} - 50th percentile",
+          "refId": "B"
+        }
+      ],
+      "title": "Dapr HTTP Request Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dapr_component_invocation_count{kubernetes_namespace=~\"$namespace\"}[5m])) by (dapr_app_id, component)",
+          "interval": "",
+          "legendFormat": "{{dapr_app_id}} - {{component}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Dapr Component Invocations (Service Bus, State Store)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dapr_service_invocation_req_sent_total{kubernetes_namespace=~\"$namespace\"}[5m])) by (dapr_app_id, target_app_id)",
+          "interval": "",
+          "legendFormat": "{{dapr_app_id}} → {{target_app_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Dapr Service-to-Service Invocations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dapr_http_server_request_count{code!~\"2..\",kubernetes_namespace=~\"$namespace\"}[5m])) by (dapr_app_id)",
+          "interval": "",
+          "legendFormat": "{{dapr_app_id}} - Error Rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Dapr HTTP Error Rate (non-2xx responses)",
+      "type": "gauge"
+    }
+  ],
+  "refresh": "30s",
+  "revision": 1,
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "dapr",
+    "microservices"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(dapr_http_server_request_count, kubernetes_namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(dapr_http_server_request_count, kubernetes_namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Dapr Metrics Dashboard",
+  "uid": "dapr-metrics",
+  "version": 1,
+  "weekStart": ""
+}

--- a/devops/helm-tools/prometheus/prometheus.sh
+++ b/devops/helm-tools/prometheus/prometheus.sh
@@ -15,18 +15,12 @@ echo "2. Create namespaces if needed"
 # Create the namespace for Prometheus if it doesn't exist
 kubectl get ns $PROM_NAMESPACE >/dev/null 2>&1 || kubectl create ns $PROM_NAMESPACE
 
-echo "3. Install/upgrade Prometheus Stack"
-# Deploy or upgrade the Prometheus stack using Helm
+echo "3. Install/upgrade Prometheus Stack with Dapr metrics support"
+# Deploy or upgrade the Prometheus stack using Helm with Dapr scraping configuration
 helm upgrade --install prom-stack prometheus-community/kube-prometheus-stack \
   --version "$PROM_CHART_VERSION" \
   --namespace "$PROM_NAMESPACE" \
-  --set grafana.enabled=false \
-  --set alertmanager.enabled=true \
-  --set prometheus.prometheusSpec.retention="2d" \
-  --set prometheus.prometheusSpec.resources.requests.memory="256Mi" \
-  --set prometheus.prometheusSpec.resources.limits.memory="512Mi" \
-  --set prometheus.prometheusSpec.scrapeInterval="60s" \
-  --set prometheus.prometheusSpec.evaluationInterval="60s" \
+  --values ./values-prometheus-dapr.yaml \
   --wait  # Wait for all resources to be ready before continuing
 
 echo "4. Wait for Grafana service to be ready"

--- a/devops/helm-tools/prometheus/values-prometheus-dapr.yaml
+++ b/devops/helm-tools/prometheus/values-prometheus-dapr.yaml
@@ -1,0 +1,86 @@
+# Prometheus configuration with Dapr metrics scraping
+prometheus:
+  prometheusSpec:
+    # Resource settings
+    retention: "2d"
+    resources:
+      requests:
+        memory: "256Mi"
+      limits:
+        memory: "512Mi"
+    scrapeInterval: "60s"
+    evaluationInterval: "60s"
+    
+    # Additional scrape configs for Dapr metrics
+    additionalScrapeConfigs:
+      # Dapr sidecar metrics (port 9090)
+      - job_name: 'dapr-sidecar-metrics'
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          # Only scrape pods with dapr.io/enabled annotation
+          - source_labels: [__meta_kubernetes_pod_annotation_dapr_io_enabled]
+            action: keep
+            regex: true
+          # Only scrape the dapr sidecar container (daprd)
+          - source_labels: [__meta_kubernetes_pod_container_name]
+            action: keep
+            regex: daprd
+          # Set the metrics path to /
+          - target_label: __metrics_path__
+            replacement: /
+          # Set the port to 9090 (Dapr metrics port)
+          - source_labels: [__meta_kubernetes_pod_ip]
+            target_label: __address__
+            replacement: ${1}:9090
+          # Add useful labels
+          - source_labels: [__meta_kubernetes_pod_annotation_dapr_io_app_id]
+            target_label: dapr_app_id
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: kubernetes_namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: kubernetes_pod_name
+        scrape_interval: 30s
+        scrape_timeout: 10s
+        
+      # Dapr placement service metrics
+      - job_name: 'dapr-placement'
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names: ['dapr-system']
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            action: keep
+            regex: dapr-placement-server
+          - source_labels: [__meta_kubernetes_pod_ip]
+            target_label: __address__
+            replacement: ${1}:9090
+          - target_label: __metrics_path__
+            replacement: /
+        scrape_interval: 60s
+        
+      # Dapr operator metrics
+      - job_name: 'dapr-operator'
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names: ['dapr-system']
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            action: keep
+            regex: dapr-operator
+          - source_labels: [__meta_kubernetes_pod_ip]
+            target_label: __address__
+            replacement: ${1}:9090
+          - target_label: __metrics_path__
+            replacement: /
+        scrape_interval: 60s
+
+# Disable Grafana (we use separate Grafana installation)
+grafana:
+  enabled: false
+
+# Keep AlertManager enabled
+alertmanager:
+  enabled: true


### PR DESCRIPTION
Added values-prometheus-dapr.yaml - Prometheus configuration with Dapr metrics scraping (port 9090)
Added dapr-metrics.json - Grafana dashboard for HTTP requests, latency, component invocations, and error tracking
Modified prometheus.sh - Include Dapr scrape configs via --values ./values-prometheus-dapr.yaml