### PR TITLE
Implementing Queue Callback Automatic Handler

### DIFF
--- a/backend/ContainerApp/Accessor/Accessor.csproj
+++ b/backend/ContainerApp/Accessor/Accessor.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="DotQueue" Version="1.0.0" />
+	<PackageReference Include="DotQueue" Version="1.0.2" />
 	<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Dapr.AspNetCore" Version="1.15.4" />

--- a/backend/ContainerApp/Accessor/Models/QueueMessages/Message.cs
+++ b/backend/ContainerApp/Accessor/Models/QueueMessages/Message.cs
@@ -16,5 +16,6 @@ public enum MessageAction
 {
     UpdateTask,
     CreateTask,
-    NotifyUser
+    NotifyUser,
+    TaskResult
 }

--- a/backend/ContainerApp/Accessor/Models/TaskResult.cs
+++ b/backend/ContainerApp/Accessor/Models/TaskResult.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace Accessor.Models;
+
+public record TaskResult(int Id, TaskResultStatus Status);
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum TaskResultStatus
+{
+    Created,
+    Updated,
+    Failed
+}

--- a/backend/ContainerApp/Accessor/Services/CallbackHeaderHelper.cs
+++ b/backend/ContainerApp/Accessor/Services/CallbackHeaderHelper.cs
@@ -1,0 +1,26 @@
+namespace Accessor.Services;
+
+public static class CallbackHeaderHelper
+{
+    public const string HeaderQueue = "x-callback-queue";
+    public const string HeaderMethod = "x-callback-method";
+
+    public static Dictionary<string, string> Create(string queueName, string methodName)
+    {
+        if (string.IsNullOrWhiteSpace(queueName))
+        {
+            throw new ArgumentException("Queue name cannot be empty", nameof(queueName));
+        }
+
+        if (string.IsNullOrWhiteSpace(methodName))
+        {
+            throw new ArgumentException("Method name cannot be empty", nameof(methodName));
+        }
+
+        return new Dictionary<string, string>
+        {
+            [HeaderQueue] = queueName,
+            [HeaderMethod] = methodName
+        };
+    }
+}

--- a/backend/ContainerApp/Accessor/Services/CallbackMetadataParser.cs
+++ b/backend/ContainerApp/Accessor/Services/CallbackMetadataParser.cs
@@ -1,0 +1,22 @@
+namespace Accessor.Services;
+
+public static class CallbackMetadataParser
+{
+    public static (string Queue, string Method)? TryParse(IReadOnlyDictionary<string, string>? metadata)
+    {
+        if (metadata == null)
+        {
+            return null;
+        }
+
+        if (metadata.TryGetValue(CallbackHeaderHelper.HeaderQueue, out var queue) &&
+            metadata.TryGetValue(CallbackHeaderHelper.HeaderMethod, out var method) &&
+            !string.IsNullOrWhiteSpace(queue) &&
+            !string.IsNullOrWhiteSpace(method))
+        {
+            return (queue, method);
+        }
+
+        return null;
+    }
+}

--- a/backend/ContainerApp/Engine/Engine.csproj
+++ b/backend/ContainerApp/Engine/Engine.csproj
@@ -9,7 +9,7 @@
 		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
 		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
 		<PackageReference Include="Dapr.AspNetCore" Version="1.15.4" />
-		<PackageReference Include="DotQueue" Version="1.0.0" />
+		<PackageReference Include="DotQueue" Version="1.0.2" />
 		<PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.45.0" />
 		<PackageReference Include="Polly" Version="8.6.2" />
 		<PackageReference Include="Microsoft.SemanticKernel" Version="1.61.0" />

--- a/backend/ContainerApp/Engine/Models/Message.cs
+++ b/backend/ContainerApp/Engine/Models/Message.cs
@@ -15,5 +15,6 @@ public enum MessageAction
     CreateTask,
     TestLongTask,
     ProcessingQuestionAi,
-    AnswerAi
+    AnswerAi,
+    TaskResult
 }

--- a/backend/ContainerApp/Engine/Models/TaskResult.cs
+++ b/backend/ContainerApp/Engine/Models/TaskResult.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace Engine.Models;
+
+public record TaskResult(int Id, TaskResultStatus Status);
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum TaskResultStatus
+{
+    Created,
+    Updated,
+    Failed
+}

--- a/backend/ContainerApp/Engine/Services/CallbackHeaderHelper.cs
+++ b/backend/ContainerApp/Engine/Services/CallbackHeaderHelper.cs
@@ -1,0 +1,26 @@
+namespace Engine.Services;
+
+public static class CallbackHeaderHelper
+{
+    public const string HeaderQueue = "x-callback-queue";
+    public const string HeaderMethod = "x-callback-method";
+
+    public static Dictionary<string, string> Create(string queueName, string methodName)
+    {
+        if (string.IsNullOrWhiteSpace(queueName))
+        {
+            throw new ArgumentException("Queue name cannot be empty", nameof(queueName));
+        }
+
+        if (string.IsNullOrWhiteSpace(methodName))
+        {
+            throw new ArgumentException("Method name cannot be empty", nameof(methodName));
+        }
+
+        return new Dictionary<string, string>
+        {
+            [HeaderQueue] = queueName,
+            [HeaderMethod] = methodName
+        };
+    }
+}

--- a/backend/ContainerApp/Engine/Services/CallbackMetadataParser.cs
+++ b/backend/ContainerApp/Engine/Services/CallbackMetadataParser.cs
@@ -1,0 +1,22 @@
+namespace Engine.Services;
+
+public static class CallbackMetadataParser
+{
+    public static (string Queue, string Method)? TryParse(IReadOnlyDictionary<string, string>? metadata)
+    {
+        if (metadata == null)
+        {
+            return null;
+        }
+
+        if (metadata.TryGetValue(CallbackHeaderHelper.HeaderQueue, out var queue) &&
+            metadata.TryGetValue(CallbackHeaderHelper.HeaderMethod, out var method) &&
+            !string.IsNullOrWhiteSpace(queue) &&
+            !string.IsNullOrWhiteSpace(method))
+        {
+            return (queue, method);
+        }
+
+        return null;
+    }
+}

--- a/backend/ContainerApp/Manager/Endpoints/ManagerQueueHandler.cs
+++ b/backend/ContainerApp/Manager/Endpoints/ManagerQueueHandler.cs
@@ -10,29 +10,33 @@ public class ManagerQueueHandler : IQueueHandler<Message>
 {
     private readonly IAiGatewayService _aiService;
     private readonly IManagerService _managerService;
+    private readonly ICallbackDispatcher _callbackDispatcher;
     private readonly ILogger<ManagerQueueHandler> _logger;
-    private readonly Dictionary<MessageAction, Func<Message, Func<Task>, CancellationToken, Task>> _handlers;
+    private readonly Dictionary<MessageAction, Func<Message, IReadOnlyDictionary<string, string>?, Func<Task>, CancellationToken, Task>> _handlers;
 
     public ManagerQueueHandler(
         IAiGatewayService aiService,
         ILogger<ManagerQueueHandler> logger,
-        IManagerService managerService)
+        IManagerService managerService,
+        ICallbackDispatcher callbackDispatcher)
     {
         _managerService = managerService;
         _aiService = aiService;
+        _callbackDispatcher = callbackDispatcher;
         _logger = logger;
-        _handlers = new Dictionary<MessageAction, Func<Message, Func<Task>, CancellationToken, Task>>
+        _handlers = new Dictionary<MessageAction, Func<Message, IReadOnlyDictionary<string, string>?, Func<Task>, CancellationToken, Task>>
         {
             [MessageAction.AnswerAi] = HandleAnswerAiAsync,
             [MessageAction.NotifyUser] = HandleNotifyUserAsync,
+            [MessageAction.TaskResult] = HandleTaskResultAsync
         };
     }
 
-    public async Task HandleAsync(Message message, Func<Task> renewLock, CancellationToken cancellationToken)
+    public async Task HandleAsync(Message message, IReadOnlyDictionary<string, string>? metadataCallback, Func<Task> renewLock, CancellationToken cancellationToken)
     {
         if (_handlers.TryGetValue(message.ActionName, out var handler))
         {
-            await handler(message, renewLock, cancellationToken);
+            await handler(message, metadataCallback, renewLock, cancellationToken);
         }
         else
         {
@@ -41,7 +45,21 @@ public class ManagerQueueHandler : IQueueHandler<Message>
         }
     }
 
-    public async Task HandleAnswerAiAsync(Message message, Func<Task> renewLock, CancellationToken cancellationToken)
+    public async Task HandleTaskResultAsync(Message message, IReadOnlyDictionary<string, string>? metadataCallback, Func<Task> renewLock, CancellationToken cancellationToken)
+    {
+        try
+        {
+            _logger.LogInformation("Dispatching TaskResult via CallbackDispatcher...");
+            await _callbackDispatcher.DispatchAsync(message, metadataCallback, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error handling TaskResult callback");
+            throw;
+        }
+    }
+
+    public async Task HandleAnswerAiAsync(Message message, IReadOnlyDictionary<string, string>? metadataCallback, Func<Task> renewLock, CancellationToken cancellationToken)
     {
         try
         {
@@ -88,7 +106,7 @@ public class ManagerQueueHandler : IQueueHandler<Message>
         }
     }
 
-    public async Task HandleNotifyUserAsync(Message message, Func<Task> renewLock, CancellationToken cancellationToken)
+    public async Task HandleNotifyUserAsync(Message message, IReadOnlyDictionary<string, string>? metadataCallback, Func<Task> renewLock, CancellationToken cancellationToken)
     {
         try
         {

--- a/backend/ContainerApp/Manager/Manager.csproj
+++ b/backend/ContainerApp/Manager/Manager.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="DotQueue" Version="1.0.0" />
+	<PackageReference Include="DotQueue" Version="1.0.2" />
 	<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Dapr.Actors.AspNetCore" Version="1.15.4" />

--- a/backend/ContainerApp/Manager/Models/QueueMessages/Message.cs
+++ b/backend/ContainerApp/Manager/Models/QueueMessages/Message.cs
@@ -10,6 +10,7 @@ public record Message
     public JsonElement Payload { get; set; }
     public JsonElement? Metadata { get; set; } = null;
 }
+
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum MessageAction
 {
@@ -18,5 +19,6 @@ public enum MessageAction
     TestLongTask,
     ProcessingQuestionAi,
     AnswerAi,
-    NotifyUser
+    NotifyUser,
+    TaskResult
 }

--- a/backend/ContainerApp/Manager/Models/TaskResult.cs
+++ b/backend/ContainerApp/Manager/Models/TaskResult.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace Manager.Models;
+
+public record TaskResult(int Id, TaskResultStatus Status);
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum TaskResultStatus
+{
+    Created,
+    Updated,
+    Failed
+}

--- a/backend/ContainerApp/Manager/Program.cs
+++ b/backend/ContainerApp/Manager/Program.cs
@@ -81,6 +81,8 @@ builder.Services.AddScoped<IAccessorClient, AccessorClient>();
 builder.Services.AddScoped<IEngineClient, EngineClient>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddScoped<IAuthService, AuthService>();
+builder.Services.AddScoped<ICallbackDispatcher, CallbackDispatcher>();
+builder.Services.AddScoped<IManagerCallbacks, ManagerCallbacks>();
 
 builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
 
@@ -155,7 +157,7 @@ var forwardedHeaderOptions = app.Services.GetRequiredService<IOptions<ForwardedH
 app.UseForwardedHeaders(forwardedHeaderOptions);
 app.UseCors("AllowAll");
 app.UseCloudEvents();
-app.UseRateLimiter();
+//app.UseRateLimiter();
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();

--- a/backend/ContainerApp/Manager/Services/CallbackDispatcher.cs
+++ b/backend/ContainerApp/Manager/Services/CallbackDispatcher.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using Manager.Models.QueueMessages;
+
+namespace Manager.Services;
+
+public class CallbackDispatcher : ICallbackDispatcher
+{
+    private readonly IServiceProvider _services;
+    private readonly ILogger<CallbackDispatcher> _logger;
+
+    public CallbackDispatcher(IServiceProvider services, ILogger<CallbackDispatcher> logger)
+    {
+        _services = services;
+        _logger = logger;
+    }
+
+    public async Task DispatchAsync(Message message, IReadOnlyDictionary<string, string>? metadataCallback, CancellationToken ct)
+    {
+        string? target = null;
+        metadataCallback?.TryGetValue(CallbackHeaderHelper.HeaderMethod, out target);
+
+        if (string.IsNullOrEmpty(target))
+        {
+            _logger.LogWarning("No callback method in metadataCallbacks for {Action}", message.ActionName);
+            return;
+        }
+
+        var callback = _services.GetService<IManagerCallbacks>();
+        var method = typeof(IManagerCallbacks).GetMethod(target);
+
+        if (callback == null || method == null)
+        {
+            _logger.LogWarning("No callback service found for {Target}", target);
+            return;
+        }
+
+        _logger.LogInformation("Dispatching callback {Target} on {Service}", target, callback.GetType().Name);
+
+        var paramType = method.GetParameters().First().ParameterType;
+        var model = message.Payload.Deserialize(paramType);
+
+        var task = (Task?)method.Invoke(callback, new[] { model! });
+        if (task != null)
+        {
+            await task;
+        }
+    }
+}

--- a/backend/ContainerApp/Manager/Services/CallbackHeaderHelper.cs
+++ b/backend/ContainerApp/Manager/Services/CallbackHeaderHelper.cs
@@ -1,0 +1,26 @@
+namespace Manager.Services;
+
+public static class CallbackHeaderHelper
+{
+    public const string HeaderQueue = "x-callback-queue";
+    public const string HeaderMethod = "x-callback-method";
+
+    public static Dictionary<string, string> Create(string queueName, string methodName)
+    {
+        if (string.IsNullOrWhiteSpace(queueName))
+        {
+            throw new ArgumentException("Queue name cannot be empty", nameof(queueName));
+        }
+
+        if (string.IsNullOrWhiteSpace(methodName))
+        {
+            throw new ArgumentException("Method name cannot be empty", nameof(methodName));
+        }
+
+        return new Dictionary<string, string>
+        {
+            [HeaderQueue] = queueName,
+            [HeaderMethod] = methodName
+        };
+    }
+}

--- a/backend/ContainerApp/Manager/Services/CallbackMetadataFactory.cs
+++ b/backend/ContainerApp/Manager/Services/CallbackMetadataFactory.cs
@@ -1,0 +1,31 @@
+namespace Manager.Services;
+
+public static class CallbackMetadataFactory
+{
+    private const string DefaultQueue = "manager-callback-queue";
+
+    public static IReadOnlyDictionary<string, string> GetCallbackMethod(string methodName)
+    {
+        if (string.IsNullOrWhiteSpace(methodName))
+        {
+            throw new ArgumentException("Method name cannot be null, empty, or whitespace.", nameof(methodName));
+        }
+
+        return CallbackHeaderHelper.Create(DefaultQueue, methodName);
+    }
+
+    public static IReadOnlyDictionary<string, string> GetCallbackMetadata(string queue, string methodName)
+    {
+        if (string.IsNullOrWhiteSpace(queue))
+        {
+            throw new ArgumentException("Queue name cannot be null, empty, or whitespace.", nameof(queue));
+        }
+
+        if (string.IsNullOrWhiteSpace(methodName))
+        {
+            throw new ArgumentException("Method name cannot be null, empty, or whitespace.", nameof(methodName));
+        }
+
+        return CallbackHeaderHelper.Create(queue, methodName);
+    }
+}

--- a/backend/ContainerApp/Manager/Services/CallbackMetadataParser.cs
+++ b/backend/ContainerApp/Manager/Services/CallbackMetadataParser.cs
@@ -1,0 +1,22 @@
+namespace Manager.Services;
+
+public static class CallbackMetadataParser
+{
+    public static (string Queue, string Method)? TryParse(IReadOnlyDictionary<string, string>? metadata)
+    {
+        if (metadata == null)
+        {
+            return null;
+        }
+
+        if (metadata.TryGetValue(CallbackHeaderHelper.HeaderQueue, out var queue) &&
+            metadata.TryGetValue(CallbackHeaderHelper.HeaderMethod, out var method) &&
+            !string.IsNullOrWhiteSpace(queue) &&
+            !string.IsNullOrWhiteSpace(method))
+        {
+            return (queue, method);
+        }
+
+        return null;
+    }
+}

--- a/backend/ContainerApp/Manager/Services/Clients/AccessorClient.cs
+++ b/backend/ContainerApp/Manager/Services/Clients/AccessorClient.cs
@@ -44,7 +44,7 @@ public class AccessorClient(
         }
     }
 
-    public async Task<bool> UpdateTaskName(int id, string newTaskName)
+    public async Task<bool> UpdateTaskName(int id, string newTaskName, IReadOnlyDictionary<string, string>? metadataCallback = null)
     {
         _logger.LogInformation("Inside: {Method} in {Class}", nameof(UpdateTaskName), nameof(AccessorClient));
         try
@@ -72,7 +72,8 @@ public class AccessorClient(
             await _daprClient.InvokeBindingAsync(
                 $"{QueueNames.AccessorQueue}-out",
                 "create",
-                message
+                message,
+                metadataCallback
             );
 
             return true;
@@ -110,7 +111,7 @@ public class AccessorClient(
         }
     }
 
-    public async Task<(bool success, string message)> PostTaskAsync(TaskModel task)
+    public async Task<(bool success, string message)> PostTaskAsync(TaskModel task, IReadOnlyDictionary<string, string>? metadataCallback = null)
     {
         _logger.LogInformation(
            "Inside: {Method} in {Class}",
@@ -137,7 +138,7 @@ public class AccessorClient(
                 Payload = payload,
                 Metadata = userContextMetadata
             };
-            await _daprClient.InvokeBindingAsync($"{QueueNames.AccessorQueue}-out", "create", message);
+            await _daprClient.InvokeBindingAsync($"{QueueNames.AccessorQueue}-out", "create", message, metadataCallback);
 
             _logger.LogDebug(
                 "Task {TaskId} sent to Accessor via binding '{Binding}'",

--- a/backend/ContainerApp/Manager/Services/Clients/Engine/EngineClient.cs
+++ b/backend/ContainerApp/Manager/Services/Clients/Engine/EngineClient.cs
@@ -19,7 +19,7 @@ public class EngineClient : IEngineClient
         _daprClient = daprClient;
     }
 
-    public async Task<(bool success, string message)> ProcessTaskLongAsync(TaskModel task)
+    public async Task<(bool success, string message)> ProcessTaskLongAsync(TaskModel task, IReadOnlyDictionary<string, string>? metadataCallback = null)
     {
         _logger.LogInformation(
             "Inside: {Method} in {Class}",
@@ -34,7 +34,7 @@ public class EngineClient : IEngineClient
                 ActionName = MessageAction.TestLongTask,
                 Payload = payload
             };
-            await _daprClient.InvokeBindingAsync($"{QueueNames.EngineQueue}-out", "create", message);
+            await _daprClient.InvokeBindingAsync($"{QueueNames.EngineQueue}-out", "create", message, metadataCallback);
 
             _logger.LogDebug(
                 "Task {TaskId} sent to Engine via binding '{Binding}'",

--- a/backend/ContainerApp/Manager/Services/Clients/Engine/IEngineClient.cs
+++ b/backend/ContainerApp/Manager/Services/Clients/Engine/IEngineClient.cs
@@ -6,7 +6,7 @@ namespace Manager.Services.Clients.Engine;
 
 public interface IEngineClient
 {
-    Task<(bool success, string message)> ProcessTaskLongAsync(TaskModel task);
+    Task<(bool success, string message)> ProcessTaskLongAsync(TaskModel task, IReadOnlyDictionary<string, string>? metadataCallback = null);
     Task<EngineChatResponse> ChatAsync(EngineChatRequest request, CancellationToken cancellationToken = default);
     Task<SpeechEngineResponse?> SynthesizeAsync(SpeechRequest request, CancellationToken cancellationToken = default);
 }

--- a/backend/ContainerApp/Manager/Services/Clients/IAccessorClient.cs
+++ b/backend/ContainerApp/Manager/Services/Clients/IAccessorClient.cs
@@ -6,9 +6,9 @@ namespace Manager.Services.Clients;
 
 public interface IAccessorClient
 {
-    Task<bool> UpdateTaskName(int id, string newTaskName);
+    Task<bool> UpdateTaskName(int id, string newTaskName, IReadOnlyDictionary<string, string>? metadataCallback = null);
     Task<bool> DeleteTask(int id);
-    Task<(bool success, string message)> PostTaskAsync(TaskModel task);
+    Task<(bool success, string message)> PostTaskAsync(TaskModel task, IReadOnlyDictionary<string, string>? metadataCallback = null);
     Task<TaskModel?> GetTaskAsync(int id);
     Task<IReadOnlyList<ChatMessage>> GetChatHistoryAsync(Guid threadId, CancellationToken ct = default);
     Task<ChatMessage?> StoreMessageAsync(ChatMessage msg, CancellationToken ct = default);

--- a/backend/ContainerApp/Manager/Services/ICallbackDispatcher.cs
+++ b/backend/ContainerApp/Manager/Services/ICallbackDispatcher.cs
@@ -1,0 +1,8 @@
+using Manager.Models.QueueMessages;
+
+namespace Manager.Services;
+
+public interface ICallbackDispatcher
+{
+    Task DispatchAsync(Message message, IReadOnlyDictionary<string, string>? metadataCallback, CancellationToken ct);
+}

--- a/backend/ContainerApp/Manager/Services/IManagerCallbacks.cs
+++ b/backend/ContainerApp/Manager/Services/IManagerCallbacks.cs
@@ -1,0 +1,9 @@
+using Manager.Models;
+
+namespace Manager.Services;
+
+public interface IManagerCallbacks
+{
+    Task OnTaskCreatedAsync(TaskResult result);
+    Task OnTaskUpdatedAsync(TaskResult result);
+}

--- a/backend/ContainerApp/Manager/Services/ManagerCallbacks.cs
+++ b/backend/ContainerApp/Manager/Services/ManagerCallbacks.cs
@@ -1,0 +1,37 @@
+using Manager.Models;
+using Manager.Hubs;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Manager.Services;
+
+public class ManagerCallbacks : IManagerCallbacks
+{
+    private readonly IHubContext<NotificationHub> _hubContext;
+    private readonly ILogger<ManagerCallbacks> _logger;
+
+    public ManagerCallbacks(IHubContext<NotificationHub> hubContext, ILogger<ManagerCallbacks> logger)
+    {
+        _hubContext = hubContext;
+        _logger = logger;
+    }
+
+    public async Task OnTaskCreatedAsync(TaskResult result)
+    {
+        _logger.LogInformation("[AUTO CALLBACK] Task {Id} created with {Status}", result.Id, result.Status);
+
+        await _hubContext.Clients.All.SendAsync(
+            "TaskCreated",
+            new TaskUpdateMessage { TaskId = result.Id, Status = result.Status.ToString() }
+        );
+    }
+
+    public async Task OnTaskUpdatedAsync(TaskResult result)
+    {
+        _logger.LogInformation("[AUTO CALLBACK] Task {Id} updated with {Status}", result.Id, result.Status);
+
+        await _hubContext.Clients.All.SendAsync(
+            "TaskUpdated",
+            new TaskUpdateMessage { TaskId = result.Id, Status = result.Status.ToString() }
+        );
+    }
+}

--- a/backend/ContainerApp/Manager/Services/ManagerService.cs
+++ b/backend/ContainerApp/Manager/Services/ManagerService.cs
@@ -86,7 +86,10 @@ public class ManagerService : IManagerService
         try
         {
             _logger.LogDebug("Posting task {TaskId} with name '{TaskName}'", task.Id, task.Name);
-            var result = await _accessorClient.PostTaskAsync(task);
+
+            var metadataCallback = CallbackMetadataFactory.GetCallbackMethod(nameof(IManagerCallbacks.OnTaskCreatedAsync));
+
+            var result = await _accessorClient.PostTaskAsync(task, metadataCallback);
             if (result.success)
             {
                 _logger.LogDebug("Task {TaskId} successfully posted to queue", task.Id);
@@ -110,7 +113,11 @@ public class ManagerService : IManagerService
         try
         {
             _logger.LogDebug("Inside: {MethodName}", nameof(CreateTaskAsync));
-            var result = await _engineClient.ProcessTaskLongAsync(task);
+
+            var metadataCallback = CallbackMetadataFactory.GetCallbackMethod(nameof(IManagerCallbacks.OnTaskCreatedAsync));
+
+            var result = await _engineClient.ProcessTaskLongAsync(task, metadataCallback);
+
             return (result.success, result.message);
         }
         catch (Exception ex)
@@ -145,7 +152,11 @@ public class ManagerService : IManagerService
         try
         {
             _logger.LogInformation("Updating task {TaskId} name to '{NewTaskName}'", id, newTaskName);
-            var result = await _accessorClient.UpdateTaskName(id, newTaskName);
+
+            var metadataCallback = CallbackMetadataFactory.GetCallbackMethod(nameof(IManagerCallbacks.OnTaskUpdatedAsync));
+
+            var result = await _accessorClient.UpdateTaskName(id, newTaskName, metadataCallback);
+
             if (result)
             {
                 _logger.LogInformation("Task {TaskId} name successfully updated", id);
@@ -176,6 +187,7 @@ public class ManagerService : IManagerService
         try
         {
             _logger.LogInformation("Attempting to delete task {TaskId}", id);
+
             var result = await _accessorClient.DeleteTask(id);
             if (result)
             {

--- a/backend/ContainerApp/UnitTests/AccessorUnitTests/ApprovalTests/AccessorQueueHandler_Invalid_Approval.cs
+++ b/backend/ContainerApp/UnitTests/AccessorUnitTests/ApprovalTests/AccessorQueueHandler_Invalid_Approval.cs
@@ -6,6 +6,7 @@ using Accessor.Models.QueueMessages;
 using Accessor.Services;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Dapr.Client;
 
 namespace AccessorUnitTests.ApprovalTests;
 
@@ -18,13 +19,14 @@ public class AccessorQueueHandler_Invalid_Approval
         var svc = new Mock<IAccessorService>(MockBehavior.Strict);
         var log = new Mock<ILogger<AccessorQueueHandler>>();
         var managerCallbackSvc = new Mock<IManagerCallbackQueueService>(MockBehavior.Strict);
+        var dapr = new Mock<DaprClient>(MockBehavior.Strict);
 
-        var handler = new AccessorQueueHandler(svc.Object, managerCallbackSvc.Object, log.Object);
+        var handler = new AccessorQueueHandler(svc.Object, managerCallbackSvc.Object, log.Object, dapr.Object);
 
         Exception? ex = null;
         try
         {
-            await handler.HandleAsync(msg, () => Task.CompletedTask, CancellationToken.None);
+            await handler.HandleAsync(msg, metadataCallback: null, () => Task.CompletedTask, CancellationToken.None);
         }
         catch (Exception e)
         {
@@ -46,6 +48,7 @@ public class AccessorQueueHandler_Invalid_Approval
         );
 
         svc.VerifyNoOtherCalls();
+        dapr.VerifyNoOtherCalls();
     }
 
     public static IEnumerable<object[]> BadMessages()

--- a/backend/ContainerApp/UnitTests/AccessorUnitTests/Endpoints/AccessorQueueHandlerTests.cs
+++ b/backend/ContainerApp/UnitTests/AccessorUnitTests/Endpoints/AccessorQueueHandlerTests.cs
@@ -7,6 +7,7 @@ using DotQueue;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Dapr.Client;
 
 namespace AccessorUnitTests.Endpoints;
 
@@ -14,6 +15,8 @@ public class AccessorQueueHandlerTests
 {
     private static Mock<IAccessorService> Svc() => new(MockBehavior.Strict);
     private static Mock<ILogger<AccessorQueueHandler>> Log() => new();
+    private static Mock<IManagerCallbackQueueService> Publisher() => new(MockBehavior.Strict);
+    private static Mock<DaprClient> Dapr() => new(MockBehavior.Strict);
 
     private static Message MakeMessage(MessageAction action, object payload)
         => new Message
@@ -22,69 +25,62 @@ public class AccessorQueueHandlerTests
             Payload = JsonSerializer.SerializeToElement(payload)
         };
 
-    // Update all instantiations of AccessorQueueHandler to include a mock IQueuePublisher as the second argument.
-
-    private static Mock<IManagerCallbackQueueService> Publisher() => new(MockBehavior.Strict);
-
     [Fact]
     public async Task HandleAsync_UpdateTask_Calls_Service()
     {
         var svc = Svc();
         var pub = Publisher();
         var log = Log();
-        var handler = new AccessorQueueHandler(svc.Object, pub.Object, log.Object);
+        var dapr = Dapr();
+
+        var handler = new AccessorQueueHandler(svc.Object, pub.Object, log.Object, dapr.Object);
 
         var payload = new TaskModel { Id = 10, Name = "new-name" };
         var msg = MakeMessage(MessageAction.UpdateTask, payload);
 
-        svc.Setup(s => s.UpdateTaskNameAsync(10, "new-name")).ReturnsAsync(true);
+        svc.Setup(s => s.UpdateTaskNameAsync(10, "new-name"))
+           .ReturnsAsync(true);
 
         var renewed = false;
         Func<Task> renew = () => { renewed = true; return Task.CompletedTask; };
 
-        await handler.HandleAsync(msg, renew, CancellationToken.None);
+        await handler.HandleAsync(msg, metadataCallback: null, renew, CancellationToken.None);
 
-        renewed.Should().BeFalse(); // current handler doesn't use renew; assert we didn't accidentally call it
+        renewed.Should().BeFalse(); // we didn't call renew
         svc.VerifyAll();
+        dapr.VerifyNoOtherCalls();
     }
+
     [Theory]
     [MemberData(nameof(InvalidMessages))]
     public async Task HandleAsync_InvalidMessage_Throws_And_NoServiceCalls(Message msg, string expectedMessagePart)
     {
-        // Arrange
         var svc = Svc();
         var pub = Publisher();
         var log = Log();
-        var handler = new AccessorQueueHandler(svc.Object, pub.Object, log.Object);
+        var dapr = Dapr();
 
-        // Act
-        Func<Task> act = () => handler.HandleAsync(msg, () => Task.CompletedTask, CancellationToken.None);
+        var handler = new AccessorQueueHandler(svc.Object, pub.Object, log.Object, dapr.Object);
 
-        // Assert
+        Func<Task> act = () => handler.HandleAsync(msg, metadataCallback: null, () => Task.CompletedTask, CancellationToken.None);
+
         await act.Should().ThrowAsync<NonRetryableException>()
                  .WithMessage($"*{expectedMessagePart}*");
 
         svc.VerifyNoOtherCalls();
+        dapr.VerifyNoOtherCalls();
     }
 
     public static IEnumerable<object[]> InvalidMessages()
     {
         yield return new object[]
         {
-            new Message
-            {
-                ActionName = (MessageAction)9999,
-                Payload = JsonDocument.Parse("{}").RootElement
-            },
+            new Message { ActionName = (MessageAction)9999, Payload = JsonDocument.Parse("{}").RootElement },
             "No handler for action"
         };
         yield return new object[]
         {
-            new Message
-            {
-                ActionName = MessageAction.UpdateTask,
-                Payload = JsonDocument.Parse("null").RootElement
-            },
+            new Message { ActionName = MessageAction.UpdateTask, Payload = JsonDocument.Parse("null").RootElement },
             "deserialization returned null"
         };
     }
@@ -95,23 +91,20 @@ public class AccessorQueueHandlerTests
         var svc = Svc();
         var pub = Publisher();
         var log = Log();
-        var handler = new AccessorQueueHandler(svc.Object, pub.Object, log.Object);
+        var dapr = Dapr();
 
-        // JSON 'null' forces Deserialize<T> to yield null -> your code throws NonRetryableException
+        var handler = new AccessorQueueHandler(svc.Object, pub.Object, log.Object, dapr.Object);
+
         var jsonNull = JsonDocument.Parse("null").RootElement;
 
-        var msg = new Message
-        {
-            ActionName = MessageAction.UpdateTask,
-            Payload = jsonNull
-        };
+        var msg = new Message { ActionName = MessageAction.UpdateTask, Payload = jsonNull };
 
-        Func<Task> act = () => handler.HandleAsync(msg, () => Task.CompletedTask, CancellationToken.None);
+        Func<Task> act = () => handler.HandleAsync(msg, metadataCallback: null, () => Task.CompletedTask, CancellationToken.None);
 
         await act.Should().ThrowAsync<NonRetryableException>()
-                 .WithMessage("*deserialization returned null*TaskModel*"); // matches "Payload deserialization returned null for TaskModel."
+                 .WithMessage("*deserialization returned null*TaskModel*");
 
-        // ensure no service calls were made
         svc.VerifyNoOtherCalls();
+        dapr.VerifyNoOtherCalls();
     }
 }

--- a/backend/ContainerApp/UnitTests/ManagerUnitTests/Services/ManagerServiceTests.cs
+++ b/backend/ContainerApp/UnitTests/ManagerUnitTests/Services/ManagerServiceTests.cs
@@ -84,7 +84,7 @@ public class ManagerServiceTests
 
         ok.Should().BeFalse();
         msg.Should().Be(expectedMsg);
-        _accessor.Verify(a => a.PostTaskAsync(It.IsAny<TaskModel>()), Times.Never);
+        _accessor.Verify(a => a.PostTaskAsync(It.IsAny<TaskModel>(), null), Times.Never);
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public class ManagerServiceTests
     {
         var sut = Create();
         var t = new TaskModel { Id = 2, Name = "ok", Payload = "p" };
-        _accessor.Setup(a => a.PostTaskAsync(t)).ReturnsAsync((true, "sent"));
+        _accessor.Setup(a => a.PostTaskAsync(t, null)).ReturnsAsync((true, "sent"));
 
         var (ok, msg) = await sut.CreateTaskAsync(t);
 
@@ -106,7 +106,7 @@ public class ManagerServiceTests
     {
         var sut = Create();
         var t = new TaskModel { Id = 3, Name = "ok", Payload = "p" };
-        _accessor.Setup(a => a.PostTaskAsync(t)).ReturnsAsync((false, "bad"));
+        _accessor.Setup(a => a.PostTaskAsync(t, null)).ReturnsAsync((false, "bad"));
 
         var (ok, msg) = await sut.CreateTaskAsync(t);
 
@@ -120,7 +120,7 @@ public class ManagerServiceTests
     {
         var sut = Create();
         var t = new TaskModel { Id = 4, Name = "ok", Payload = "p" };
-        _accessor.Setup(a => a.PostTaskAsync(t)).ThrowsAsync(new Exception("boom"));
+        _accessor.Setup(a => a.PostTaskAsync(t, null)).ThrowsAsync(new Exception("boom"));
 
         var (ok, msg) = await sut.CreateTaskAsync(t);
 
@@ -135,7 +135,7 @@ public class ManagerServiceTests
     {
         var sut = Create();
         var t = new TaskModel { Id = 9, Name = "n", Payload = "p" };
-        _engine.Setup(e => e.ProcessTaskLongAsync(t)).ReturnsAsync((true, "ok"));
+        _engine.Setup(e => e.ProcessTaskLongAsync(t, null)).ReturnsAsync((true, "ok"));
 
         var (ok, msg) = await sut.ProcessTaskLongAsync(t);
 
@@ -149,7 +149,7 @@ public class ManagerServiceTests
     {
         var sut = Create();
         var t = new TaskModel { Id = 9, Name = "n", Payload = "p" };
-        _engine.Setup(e => e.ProcessTaskLongAsync(t)).ThrowsAsync(new Exception("x"));
+        _engine.Setup(e => e.ProcessTaskLongAsync(t, null)).ThrowsAsync(new Exception("x"));
 
         var (ok, msg) = await sut.ProcessTaskLongAsync(t);
 
@@ -168,14 +168,14 @@ public class ManagerServiceTests
         (await sut.UpdateTaskName(1, "")).Should().BeFalse();
         (await sut.UpdateTaskName(1, new string('a', 101))).Should().BeFalse();
 
-        _accessor.Verify(a => a.UpdateTaskName(It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+        _accessor.Verify(a => a.UpdateTaskName(It.IsAny<int>(), It.IsAny<string>(), null), Times.Never);
     }
 
     [Fact]
     public async Task UpdateTaskName_Success_ReturnsTrue()
     {
         var sut = Create();
-        _accessor.Setup(a => a.UpdateTaskName(5, "new")).ReturnsAsync(true);
+        _accessor.Setup(a => a.UpdateTaskName(5, "new", null)).ReturnsAsync(true);
 
         var ok = await sut.UpdateTaskName(5, "new");
 
@@ -187,7 +187,7 @@ public class ManagerServiceTests
     public async Task UpdateTaskName_WhenAccessorReturnsFalse_ReturnsFalse()
     {
         var sut = Create();
-        _accessor.Setup(a => a.UpdateTaskName(6, "x")).ReturnsAsync(false);
+        _accessor.Setup(a => a.UpdateTaskName(6, "x", null)).ReturnsAsync(false);
 
         var ok = await sut.UpdateTaskName(6, "x");
 
@@ -199,7 +199,7 @@ public class ManagerServiceTests
     public async Task UpdateTaskName_WhenAccessorThrows_ReturnsFalse()
     {
         var sut = Create();
-        _accessor.Setup(a => a.UpdateTaskName(7, "x")).ThrowsAsync(new Exception("fail"));
+        _accessor.Setup(a => a.UpdateTaskName(7, "x", null)).ThrowsAsync(new Exception("fail"));
 
         var ok = await sut.UpdateTaskName(7, "x");
 


### PR DESCRIPTION
Enable automatic callback handling between services using queue metadata. This allows services to send messages with callback information (which queue and which method should handle the response) and have them automatically dispatched to the correct method when received.

## 1. Callback Header Helper
Created CallbackHeaderHelper to standardize the callback metadata keys:
- x-callback-queue → identifies the target queue.
- x-callback-method → identifies the target callback method.

Added validation with exceptions (ArgumentException) to ensure queue and method names cannot be null, empty, or whitespace.

## 2. Callback Metadata Factory
Built CallbackMetadataFactory to simplify creating metadata:
- GetCallbackMethod(methodName) → creates metadata for the default queue (manager-callback-queue).
- GetCallbackMetadata(queue, methodName) → creates metadata for a specific queue and method.

Added input validation and exceptions to prevent invalid metadata.

## 3. Callback Metadata Parser
Added CallbackMetadataParser to extract (Queue, Method) safely from metadata dictionaries.
Returns null if metadata is missing or invalid, ensuring robust error handling.

## 4. Callback Dispatcher
Implemented CallbackDispatcher:
- Reads the target callback method from metadata.
- Resolves the callback service from DI.
- Uses reflection to find the method.
- Deserializes the message payload into the method’s parameter type.
- Invokes the method asynchronously if it returns a Task.

Handles missing metadata or invalid targets with warning logs.

## 5. Manager Callbacks Implementation
Defined IManagerCallbacks interface with:
- OnTaskCreatedAsync(TaskResult result)
- OnTaskUpdatedAsync(TaskResult result)

Implemented ManagerCallbacks:
- Uses SignalR Hub (NotificationHub) to broadcast task creation/update events to connected clients.
- Logs all callback activity for traceability.