### PR TITLE
Snir/423/cypress tests vitest tests are inside the workflow

### DIFF
--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -83,7 +83,6 @@ jobs:
             timeout 30s npx vitest run \
               --reporter=verbose \
               --passWithNoTests \
-              --coverage \
               --root apps/${{ matrix.app }}
             EXIT_CODE=$?
             if [ $EXIT_CODE -eq 124 ]; then

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -75,15 +75,24 @@ jobs:
         run: npm ci
 
       - name: Run Vitest for ${{ matrix.app }}
-        working-directory: ${{ env.FE_DIR }}/apps/${{ matrix.app }}
+        working-directory: ${{ env.FE_DIR }}
         timeout-minutes: 1
         run: |
-          echo "Running Vitest for ${{ matrix.app }}..."
-          timeout 30s npx vitest run --reporter=verbose --passWithNoTests --coverage
-          EXIT_CODE=$?
-          if [ $EXIT_CODE -eq 124 ]; then
-            echo "❌ Vitest for ${{ matrix.app }} timed out after 30s"
-            exit 1
+          if grep -q "\"test:${{ matrix.app }}\":" package.json; then
+            echo "Running Vitest for ${{ matrix.app }}..."
+            timeout 30s npx vitest run \
+              --reporter=verbose \
+              --passWithNoTests \
+              --coverage \
+              --root apps/${{ matrix.app }}
+            EXIT_CODE=$?
+            if [ $EXIT_CODE -eq 124 ]; then
+              echo "❌ Vitest for ${{ matrix.app }} timed out after 30s"
+              exit 1
+            fi
+            echo "✅ Tests completed successfully for ${{ matrix.app }}"
+          else
+            echo "⚠️ No test:${{ matrix.app }} script found in package.json - skipping"
           fi
 
   frontend-build-and-lint:

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -82,11 +82,33 @@ jobs:
           echo "Tests completed successfully for ${{ matrix.app }}"
       
       - name: Run E2E Tests (Cypress) for ${{ matrix.app }}
+        continue-on-error: true
         working-directory: ${{ env.FE_DIR }}
+        env:
+          # Required for Azure Speech SDK (speakingPractice tests)
+          VITE_AZURE_SPEECH_KEY: ${{ secrets.VITE_AZURE_SPEECH_KEY }}
+          VITE_AZURE_REGION: "eastus"
+          # Required for weather tests
+          VITE_OPENWEATHERMAP_API_KEY: ${{ secrets.VITE_OPENWEATHERMAP_API_KEY }}
+          # Backend API configuration for user tests
+          VITE_BASE_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev"
+          VITE_AI_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev/ai-manager"
+          VITE_AUTH_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev/auth"
+          VITE_TASKS_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev/tasks-manager"
+          VITE_USERS_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev/users-manager"
+          # Other required environment variables
+          VITE_AZURE_OPENAI_KEY: ""
+          VITE_AZURE_OPENAI_DEPLOYMENT_NAME: "gpt-4.1-mini"
+          VITE_AZURE_OPENAI_API_VERSION: "2024-04-01-preview"
+          VITE_AZURE_OPENAI_ENDPOINT: "https://france-teachin-open-ai.openai.azure.com/"
+          VITE_APPINSIGHTS_CONNECTION_STRING: ""
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
         run: |
           echo "Running Cypress for ${{ matrix.app }}..."
           if grep -q "\"cypress:${{ matrix.app }}\":" package.json; then
+            # Run Cypress - will show results even with some test failures
             npm run cypress:${{ matrix.app }}:ci
+            echo "Cypress run completed for ${{ matrix.app }}"
           else
             echo "No cypress:${{ matrix.app }} script found in package.json - skipping"
           fi

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -131,7 +131,7 @@ jobs:
 
 
   frontend-build-and-lint:
-    needs: [frontend-test]
+    #needs: [frontend-test]
     if: inputs.run_only_tests == true
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -80,7 +80,7 @@ jobs:
           # Check if test script exists in package.json
           if grep -q "\"test:${{ matrix.app }}\":" package.json; then
             echo "Running tests for ${{ matrix.app }}..."
-            nx run student:test --run --ci --skip-nx-cache --reporter=verbose
+            npm run test:${{ matrix.app }} -- --run --ci --skip-nx-cache --no-watch --reporter=verbose --exit --forceExit --detectOpenHandles
             echo "Tests completed successfully for ${{ matrix.app }}"
           else
             echo "No test:${{ matrix.app }} script found in package.json - skipping"
@@ -172,9 +172,9 @@ jobs:
 
   deploy:
     if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call'
+     github.event_name == 'push' ||
+     github.event_name == 'workflow_dispatch' ||
+     github.event_name == 'workflow_call'
     needs: [frontend-build-and-lint]
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment || 'Development' }}

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -74,25 +74,18 @@ jobs:
         working-directory: ${{ env.FE_DIR }}
         run: npm ci
 
-      - name: Run Vitest for ${{ matrix.app }}
+      - name: Run Tests for ${{ matrix.app }}
         working-directory: ${{ env.FE_DIR }}
-        timeout-minutes: 1
         run: |
+          # Check if test script exists in package.json
           if grep -q "\"test:${{ matrix.app }}\":" package.json; then
-            echo "Running Vitest for ${{ matrix.app }}..."
-            timeout 30s npx vitest run \
-              --reporter=verbose \
-              --passWithNoTests \
-              --root apps/${{ matrix.app }}
-            EXIT_CODE=$?
-            if [ $EXIT_CODE -eq 124 ]; then
-              echo "❌ Vitest for ${{ matrix.app }} timed out after 30s"
-              exit 1
-            fi
-            echo "✅ Tests completed successfully for ${{ matrix.app }}"
+            echo "Running tests for ${{ matrix.app }}..."
+            npx vitest run --reporter=verbose --passWithNoTests --coverage --root apps/${{ matrix.app }}
+            echo "Tests completed successfully for ${{ matrix.app }}"
           else
-            echo "⚠️ No test:${{ matrix.app }} script found in package.json - skipping"
+            echo "No test:${{ matrix.app }} script found in package.json - skipping"
           fi
+
 
   frontend-build-and-lint:
     if: false

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -131,8 +131,8 @@ jobs:
 
 
   frontend-build-and-lint:
-    #needs: [frontend-test]
     if: inputs.run_only_tests == false
+    needs: [frontend-test]
     runs-on: ubuntu-latest
     env:
       FE_DIR: frontend

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -29,6 +29,11 @@ on:
         description: 'lowercase letters & digits only (env identifier) where the application is deployed'
         required: true
         type: string
+      run_only_tests:
+        description: 'Run frontend tests before deployment'
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       environment:
@@ -43,6 +48,10 @@ on:
       deployment_token:
         required: false
         type: string
+      run_only_tests:
+        required: false
+        type: boolean
+        default: true
     secrets:
       AZURE_STATIC_WEB_APPS_API_TOKEN:
         required: false
@@ -122,8 +131,8 @@ jobs:
 
 
   frontend-build-and-lint:
-    if: false
     needs: [frontend-test]
+    if: inputs.run_only_tests == true
     runs-on: ubuntu-latest
     env:
       FE_DIR: frontend

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -80,7 +80,7 @@ jobs:
           # Check if test script exists in package.json
           if grep -q "\"test:${{ matrix.app }}\":" package.json; then
             echo "Running tests for ${{ matrix.app }}..."
-            npx nx test ${{ matrix.app }} -- --run --ci --skip-nx-cache --no-watch--reporter=verbose --exit --forceExit --detectOpenHandles
+            npx nx test ${{ matrix.app }} -- --run
             echo "Tests completed successfully for ${{ matrix.app }}"
           else
             echo "No test:${{ matrix.app }} script found in package.json - skipping"
@@ -88,6 +88,7 @@ jobs:
 
 
   frontend-build-and-lint:
+    if: false
     needs: [frontend-test]
     runs-on: ubuntu-latest
     env:
@@ -171,9 +172,9 @@ jobs:
 
   deploy:
     if: |
-     github.event_name == 'push' ||
-     github.event_name == 'workflow_dispatch' ||
-     github.event_name == 'workflow_call'
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call'
     needs: [frontend-build-and-lint]
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment || 'Development' }}

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -30,9 +30,9 @@ on:
         required: true
         type: string
       run_only_tests:
-        description: 'Run frontend tests before deployment'
+        description: 'Run only frontend tests'
         required: false
-        default: false
+        default: true
         type: boolean
   workflow_call:
     inputs:
@@ -51,7 +51,7 @@ on:
       run_only_tests:
         required: false
         type: boolean
-        default: true
+        default: false
     secrets:
       AZURE_STATIC_WEB_APPS_API_TOKEN:
         required: false
@@ -132,7 +132,7 @@ jobs:
 
   frontend-build-and-lint:
     #needs: [frontend-test]
-    if: inputs.run_only_tests == true
+    if: inputs.run_only_tests == false
     runs-on: ubuntu-latest
     env:
       FE_DIR: frontend

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -86,9 +86,9 @@ jobs:
         run: |
           echo "Running Cypress for ${{ matrix.app }}..."
           if grep -q "\"cypress:${{ matrix.app }}\":" package.json; then
-            npm run cypress:${{ matrix.app }}
+            npm run cypress:${{ matrix.app }}:ci
           else
-            echo "⚠️ No cypress:${{ matrix.app }} script found in package.json - skipping"
+            echo "No cypress:${{ matrix.app }} script found in package.json - skipping"
           fi
 
 

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -80,7 +80,7 @@ jobs:
           # Check if test script exists in package.json
           if grep -q "\"test:${{ matrix.app }}\":" package.json; then
             echo "Running tests for ${{ matrix.app }}..."
-            npx vitest run --reporter=verbose --passWithNoTests --coverage --root apps/${{ matrix.app }}
+            npx vitest run --reporter=verbose --passWithNoTests --root apps/${{ matrix.app }}
             echo "Tests completed successfully for ${{ matrix.app }}"
           else
             echo "No test:${{ matrix.app }} script found in package.json - skipping"

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -80,7 +80,7 @@ jobs:
           # Check if test script exists in package.json
           if grep -q "\"test:${{ matrix.app }}\":" package.json; then
             echo "Running tests for ${{ matrix.app }}..."
-            npm run test:${{ matrix.app }} -- --ci --reporter=verbose --no-watch --forceExit
+            npm run test:${{ matrix.app }} -- --ci --reporter=verbose --no-watch --run --exit
             echo "Tests completed successfully for ${{ matrix.app }}"
           else
             echo "No test:${{ matrix.app }} script found in package.json - skipping"

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -74,18 +74,17 @@ jobs:
         working-directory: ${{ env.FE_DIR }}
         run: npm ci
 
-      - name: Run Tests for ${{ matrix.app }}
-        working-directory: ${{ env.FE_DIR }}
+      - name: Run Vitest for ${{ matrix.app }}
+        working-directory: ${{ env.FE_DIR }}/apps/${{ matrix.app }}
+        timeout-minutes: 1
         run: |
-          # Check if test script exists in package.json
-          if grep -q "\"test:${{ matrix.app }}\":" package.json; then
-            echo "Running tests for ${{ matrix.app }}..."
-            npm run test:${{ matrix.app }} -- --run --ci --skip-nx-cache --no-watch --reporter=verbose --exit --forceExit --detectOpenHandles
-            echo "Tests completed successfully for ${{ matrix.app }}"
-          else
-            echo "No test:${{ matrix.app }} script found in package.json - skipping"
+          echo "Running Vitest for ${{ matrix.app }}..."
+          timeout 30s npx vitest run --reporter=verbose --passWithNoTests --coverage
+          EXIT_CODE=$?
+          if [ $EXIT_CODE -eq 124 ]; then
+            echo "❌ Vitest for ${{ matrix.app }} timed out after 30s"
+            exit 1
           fi
-
 
   frontend-build-and-lint:
     if: false

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -80,7 +80,7 @@ jobs:
           # Check if test script exists in package.json
           if grep -q "\"test:${{ matrix.app }}\":" package.json; then
             echo "Running tests for ${{ matrix.app }}..."
-            npm run test:${{ matrix.app }} -- --run --no-watch
+            npm run test:${{ matrix.app }} -- --ci --reporter=verbose --no-watch
             echo "Tests completed successfully for ${{ matrix.app }}"
           else
             echo "No test:${{ matrix.app }} script found in package.json - skipping"

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -77,10 +77,15 @@ jobs:
       - name: Run Tests for ${{ matrix.app }}
         working-directory: ${{ env.FE_DIR }}
         run: |
-          # Check if test script exists in package.json
           echo "Running tests for ${{ matrix.app }}..."
           npx vitest run --reporter=verbose --passWithNoTests --root apps/${{ matrix.app }}
           echo "Tests completed successfully for ${{ matrix.app }}"
+      
+      - name: Run E2E Tests (Cypress) for ${{ matrix.app }}
+        working-directory: ${{ env.FE_DIR }}
+        run: |
+          echo "Running Cypress for ${{ matrix.app }}..."
+          npm run cypress:${{ matrix.app }} -- --headless
 
 
   frontend-build-and-lint:

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -53,42 +53,42 @@ concurrency:
 
 jobs:
 
-  # frontend-test:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       app: [student, teacher, admin]
-  #   env:
-  #     FE_DIR: frontend
-  #   steps:
-  #     - uses: actions/checkout@v4
+  frontend-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: [student, teacher, admin]
+    env:
+      FE_DIR: frontend
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: Setup Node.js
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: '20'
-  #         cache: 'npm'
-  #         cache-dependency-path: '${{ env.FE_DIR }}/package-lock.json'
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: '${{ env.FE_DIR }}/package-lock.json'
 
-  #     - name: Install Dependencies
-  #       working-directory: ${{ env.FE_DIR }}
-  #       run: npm ci
+      - name: Install Dependencies
+        working-directory: ${{ env.FE_DIR }}
+        run: npm ci
 
-  #     - name: Run Tests for ${{ matrix.app }}
-  #       working-directory: ${{ env.FE_DIR }}
-  #       run: |
-  #         # Check if test script exists in package.json
-  #         if grep -q "\"test:${{ matrix.app }}\":" package.json; then
-  #           echo "Running tests for ${{ matrix.app }}..."
-  #           npm run test:${{ matrix.app }} -- --run --no-watch
-  #           echo "Tests completed successfully for ${{ matrix.app }}"
-  #         else
-  #           echo "No test:${{ matrix.app }} script found in package.json - skipping"
-  #         fi
+      - name: Run Tests for ${{ matrix.app }}
+        working-directory: ${{ env.FE_DIR }}
+        run: |
+          # Check if test script exists in package.json
+          if grep -q "\"test:${{ matrix.app }}\":" package.json; then
+            echo "Running tests for ${{ matrix.app }}..."
+            npm run test:${{ matrix.app }} -- --run --no-watch
+            echo "Tests completed successfully for ${{ matrix.app }}"
+          else
+            echo "No test:${{ matrix.app }} script found in package.json - skipping"
+          fi
 
 
   frontend-build-and-lint:
-    # needs: [frontend-test]
+    needs: [frontend-test]
     runs-on: ubuntu-latest
     env:
       FE_DIR: frontend

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -51,6 +51,32 @@ concurrency:
   group: deploy-frontend-apps-${{ inputs.environment_name || github.event.inputs.environment_name || 'dev' }}
   cancel-in-progress: false
 
+env:
+  # Azure Speech SDK configuration
+  VITE_AZURE_SPEECH_KEY: ${{ secrets.VITE_AZURE_SPEECH_KEY }}
+  VITE_AZURE_REGION: "eastus"
+  
+  # External APIs
+  VITE_OPENWEATHERMAP_API_KEY: ${{ secrets.VITE_OPENWEATHERMAP_API_KEY }}
+  
+  # Backend microservices URLs
+  VITE_BASE_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev"
+  VITE_AI_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev/ai-manager"
+  VITE_AUTH_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev/auth"
+  VITE_TASKS_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev/tasks-manager"
+  VITE_USERS_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev/users-manager"
+  
+  # Azure OpenAI configuration
+  VITE_AZURE_OPENAI_KEY: ""
+  VITE_AZURE_OPENAI_DEPLOYMENT_NAME: "gpt-4.1-mini"
+  VITE_AZURE_OPENAI_API_VERSION: "2024-04-01-preview"
+  VITE_AZURE_OPENAI_ENDPOINT: "https://france-teachin-open-ai.openai.azure.com/"
+  
+  # Monitoring and tracking
+  VITE_APPINSIGHTS_CONNECTION_STRING: ""
+  VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
 jobs:
 
   frontend-test:
@@ -84,25 +110,6 @@ jobs:
       - name: Run E2E Tests (Cypress) for ${{ matrix.app }}
         continue-on-error: true
         working-directory: ${{ env.FE_DIR }}
-        env:
-          # Required for Azure Speech SDK (speakingPractice tests)
-          VITE_AZURE_SPEECH_KEY: ${{ secrets.VITE_AZURE_SPEECH_KEY }}
-          VITE_AZURE_REGION: "eastus"
-          # Required for weather tests
-          VITE_OPENWEATHERMAP_API_KEY: ${{ secrets.VITE_OPENWEATHERMAP_API_KEY }}
-          # Backend API configuration for user tests
-          VITE_BASE_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev"
-          VITE_AI_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev/ai-manager"
-          VITE_AUTH_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev/auth"
-          VITE_TASKS_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev/tasks-manager"
-          VITE_USERS_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev/users-manager"
-          # Other required environment variables
-          VITE_AZURE_OPENAI_KEY: ""
-          VITE_AZURE_OPENAI_DEPLOYMENT_NAME: "gpt-4.1-mini"
-          VITE_AZURE_OPENAI_API_VERSION: "2024-04-01-preview"
-          VITE_AZURE_OPENAI_ENDPOINT: "https://france-teachin-open-ai.openai.azure.com/"
-          VITE_APPINSIGHTS_CONNECTION_STRING: ""
-          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
         run: |
           echo "Running Cypress for ${{ matrix.app }}..."
           if grep -q "\"cypress:${{ matrix.app }}\":" package.json; then
@@ -146,21 +153,7 @@ jobs:
       - name: Build All Applications (Parallel)
         working-directory: ${{ env.FE_DIR }}
         env:
-          VITE_AZURE_SPEECH_KEY: ""
-          VITE_AZURE_REGION: "eastus"
-          VITE_AZURE_OPENAI_KEY: ""
-          VITE_AZURE_OPENAI_DEPLOYMENT_NAME: "gpt-4.1-mini"
-          VITE_AZURE_OPENAI_API_VERSION: "2024-04-01-preview"
-          VITE_AZURE_OPENAI_ENDPOINT: "https://france-teachin-open-ai.openai.azure.com/"
-          VITE_APPINSIGHTS_CONNECTION_STRING: ""
-          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
-          VITE_OPENWEATHERMAP_API_KEY: ${{ secrets.VITE_OPENWEATHERMAP_API_KEY }}
-          VITE_BASE_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev"
-          VITE_AI_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev/ai-manager"
-          VITE_AUTH_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev/auth"
-          VITE_TASKS_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev/tasks-manager"
-          VITE_USERS_URL: "https://teachin.westeurope.cloudapp.azure.com/api/dev/users-manager"
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          # Build-specific environment variables (RELEASE_NAME is created in the previous step)
           RELEASE: ${{ env.RELEASE_NAME }}
         run: |
           echo "Starting parallel builds for all frontend applications..."

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -80,7 +80,7 @@ jobs:
           # Check if test script exists in package.json
           if grep -q "\"test:${{ matrix.app }}\":" package.json; then
             echo "Running tests for ${{ matrix.app }}..."
-            npm run test:${{ matrix.app }} -- --ci --reporter=verbose --no-watch --run --exit
+            npx nx test ${{ matrix.app }} -- --run --ci --skip-nx-cache --no-watch--reporter=verbose --exit --forceExit --detectOpenHandles
             echo "Tests completed successfully for ${{ matrix.app }}"
           else
             echo "No test:${{ matrix.app }} script found in package.json - skipping"

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -80,7 +80,7 @@ jobs:
           # Check if test script exists in package.json
           if grep -q "\"test:${{ matrix.app }}\":" package.json; then
             echo "Running tests for ${{ matrix.app }}..."
-            npm run test:${{ matrix.app }} -- --ci --reporter=verbose --no-watch
+            npm run test:${{ matrix.app }} -- --ci --reporter=verbose --no-watch --forceExit
             echo "Tests completed successfully for ${{ matrix.app }}"
           else
             echo "No test:${{ matrix.app }} script found in package.json - skipping"

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -80,7 +80,7 @@ jobs:
           # Check if test script exists in package.json
           if grep -q "\"test:${{ matrix.app }}\":" package.json; then
             echo "Running tests for ${{ matrix.app }}..."
-            npx nx test ${{ matrix.app }} -- --run
+            nx run student:test --run --ci --skip-nx-cache --reporter=verbose
             echo "Tests completed successfully for ${{ matrix.app }}"
           else
             echo "No test:${{ matrix.app }} script found in package.json - skipping"

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -85,7 +85,11 @@ jobs:
         working-directory: ${{ env.FE_DIR }}
         run: |
           echo "Running Cypress for ${{ matrix.app }}..."
-          npm run cypress:${{ matrix.app }} -- --headless
+          if grep -q "\"cypress:${{ matrix.app }}\":" package.json; then
+            npm run cypress:${{ matrix.app }}
+          else
+            echo "⚠️ No cypress:${{ matrix.app }} script found in package.json - skipping"
+          fi
 
 
   frontend-build-and-lint:

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -78,13 +78,9 @@ jobs:
         working-directory: ${{ env.FE_DIR }}
         run: |
           # Check if test script exists in package.json
-          if grep -q "\"test:${{ matrix.app }}\":" package.json; then
-            echo "Running tests for ${{ matrix.app }}..."
-            npx vitest run --reporter=verbose --passWithNoTests --root apps/${{ matrix.app }}
-            echo "Tests completed successfully for ${{ matrix.app }}"
-          else
-            echo "No test:${{ matrix.app }} script found in package.json - skipping"
-          fi
+          echo "Running tests for ${{ matrix.app }}..."
+          npx vitest run --reporter=verbose --passWithNoTests --root apps/${{ matrix.app }}
+          echo "Tests completed successfully for ${{ matrix.app }}"
 
 
   frontend-build-and-lint:

--- a/frontend/apps/student/project.json
+++ b/frontend/apps/student/project.json
@@ -60,6 +60,7 @@
       "options": {
         "cypressConfig": "apps/student/cypress.config.ts",
         "testingType": "e2e",
+        "devServerTarget": "student:serve:development",
         "watch": false
       }
     },

--- a/frontend/apps/student/project.json
+++ b/frontend/apps/student/project.json
@@ -60,7 +60,7 @@
       "options": {
         "cypressConfig": "apps/student/cypress.config.ts",
         "testingType": "e2e",
-        "watch": true
+        "watch": false
       }
     },
     "lint": {

--- a/frontend/apps/student/project.json
+++ b/frontend/apps/student/project.json
@@ -57,11 +57,19 @@
     },
     "cypress-open": {
       "executor": "@nx/cypress:cypress",
+      "defaultConfiguration": "local",
       "options": {
         "cypressConfig": "apps/student/cypress.config.ts",
-        "testingType": "e2e",
-        "devServerTarget": "student:serve:development",
-        "watch": false
+        "testingType": "e2e"
+      },
+      "configurations": {
+        "ci": {
+          "devServerTarget": "student:serve:development",
+          "watch": false
+        },
+        "local": {
+          "watch": true
+        }
       }
     },
     "lint": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "serve:teacher": "nx serve teacher",
     "serve:admin": "nx serve admin",
     "cypress:student": "nx run student:cypress-open",
+    "cypress:student:ci": "nx run student:cypress-open:ci",
     "test:student": "nx run student:test -- --reporter=verbose",
     "test-fix:student": "nx run student:test -- -u",
     "storybook:student": "nx run student:storybook"


### PR DESCRIPTION
Added comprehensive frontend-test job - Runs both Vitest unit tests and Cypress E2E tests in parallel across all frontend apps (student, teacher, admin) with matrix strategy for faster execution.

Configured global environment variables - Set up all required API keys and service URLs (Azure Speech, OpenWeatherMap, backend microservices) at workflow level to resolve test failures and ensure proper API connectivity.

Implemented flexible test control - Added run_only_tests dispatch option to allow running tests-only mode or skipping tests entirely, with smart job dependencies and continue-on-error to prevent test failures from blocking deployments.

Added Cypress CI scripts - Modified package.json, project.json to include cypress:{app}:ci scripts for running Cypress tests in CI mode