### PR TITLE
Shirley/620/send user id while creating a user

### DIFF
--- a/frontend/libs/app-providers/src/auth/provider/index.tsx
+++ b/frontend/libs/app-providers/src/auth/provider/index.tsx
@@ -127,6 +127,7 @@ export const AuthProvider = ({ children, appRole }: AuthProviderProps) => {
   const signup = useCallback(
     async (data: SignupData) => {
       await createUserMutation({
+        userId: crypto.randomUUID(),
         email: data.email,
         password: data.password,
         firstName: data.firstName,

--- a/frontend/libs/app-providers/src/types/user/index.ts
+++ b/frontend/libs/app-providers/src/types/user/index.ts
@@ -1,6 +1,7 @@
 import { AppRoleType } from "../auth";
 
 export interface CreateUserRequest {
+  userId: string;
   email: string;
   password: string;
   firstName: string;


### PR DESCRIPTION
#620 
i asked Shahar, and he said the backend doesnt create a userId when creating a user (signing up)
so the frontend should send the user id
before this PR, the response of the userId looked like that:
userId: "00000 - 00000 - 00000 - 0000"
now it looks like that ( sending crypto.randomUUID() ):
<img width="388" height="150" alt="image" src="https://github.com/user-attachments/assets/b2c1d676-1b29-43d8-a007-5121f6916871" />
