### PR TITLE
Add preferred language and Hebrew level support for users

### DIFF
--- a/backend/ContainerApp/Accessor/DB/Configurations/UsersConfiguration.cs
+++ b/backend/ContainerApp/Accessor/DB/Configurations/UsersConfiguration.cs
@@ -30,6 +30,15 @@ public class UsersConfiguration : IEntityTypeConfiguration<UserModel>
             .HasConversion<string>() // Store enum as string
             .IsRequired();
 
+        builder.Property(u => u.PreferredLanguageCode)
+            .HasConversion<string>() // enum → string
+            .HasDefaultValue(SupportedLanguage.en) // default if not set
+            .IsRequired();
+
+        builder.Property(u => u.HebrewLevelValue)
+            .HasConversion<string>() // nullable enum → string
+            .IsRequired(false); // optional
+
         builder.HasIndex(u => u.Email)
             .IsUnique();
 

--- a/backend/ContainerApp/Accessor/Migrations/20250904135920_AddPreferredLanguageAndHebrewLevelToUsers.Designer.cs
+++ b/backend/ContainerApp/Accessor/Migrations/20250904135920_AddPreferredLanguageAndHebrewLevelToUsers.Designer.cs
@@ -4,6 +4,7 @@ using System.Net;
 using Accessor.DB;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Accessor.Migrations
 {
     [DbContext(typeof(AccessorDbContext))]
-    partial class AccessorDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250904135920_AddPreferredLanguageAndHebrewLevelToUsers")]
+    partial class AddPreferredLanguageAndHebrewLevelToUsers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -171,8 +174,8 @@ namespace Accessor.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<string>("HebrewLevelValue")
-                        .HasColumnType("text");
+                    b.Property<int?>("HebrewLevelValue")
+                        .HasColumnType("integer");
 
                     b.Property<string>("LastName")
                         .IsRequired()
@@ -183,11 +186,8 @@ namespace Accessor.Migrations
                         .HasMaxLength(255)
                         .HasColumnType("character varying(255)");
 
-                    b.Property<string>("PreferredLanguageCode")
-                        .IsRequired()
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("text")
-                        .HasDefaultValue("en");
+                    b.Property<int>("PreferredLanguageCode")
+                        .HasColumnType("integer");
 
                     b.Property<string>("Role")
                         .IsRequired()

--- a/backend/ContainerApp/Accessor/Migrations/20250904135920_AddPreferredLanguageAndHebrewLevelToUsers.cs
+++ b/backend/ContainerApp/Accessor/Migrations/20250904135920_AddPreferredLanguageAndHebrewLevelToUsers.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Accessor.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPreferredLanguageAndHebrewLevelToUsers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "HebrewLevelValue",
+                table: "Users",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PreferredLanguageCode",
+                table: "Users",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "HebrewLevelValue",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "PreferredLanguageCode",
+                table: "Users");
+        }
+    }
+}

--- a/backend/ContainerApp/Accessor/Migrations/20250904142400_UpdateUserEnumConversions.Designer.cs
+++ b/backend/ContainerApp/Accessor/Migrations/20250904142400_UpdateUserEnumConversions.Designer.cs
@@ -4,6 +4,7 @@ using System.Net;
 using Accessor.DB;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Accessor.Migrations
 {
     [DbContext(typeof(AccessorDbContext))]
-    partial class AccessorDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250904142400_UpdateUserEnumConversions")]
+    partial class UpdateUserEnumConversions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/ContainerApp/Accessor/Migrations/20250904142400_UpdateUserEnumConversions.cs
+++ b/backend/ContainerApp/Accessor/Migrations/20250904142400_UpdateUserEnumConversions.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Accessor.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateUserEnumConversions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "PreferredLanguageCode",
+                table: "Users",
+                type: "text",
+                nullable: false,
+                defaultValue: "en",
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "HebrewLevelValue",
+                table: "Users",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "PreferredLanguageCode",
+                table: "Users",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldDefaultValue: "en");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "HebrewLevelValue",
+                table: "Users",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+        }
+    }
+}

--- a/backend/ContainerApp/Accessor/Models/Users/HebrewLevel.cs
+++ b/backend/ContainerApp/Accessor/Models/Users/HebrewLevel.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Accessor.Models.Users;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum HebrewLevel
+{
+    beginner,
+    intermediate,
+    advanced,
+    fluent
+}

--- a/backend/ContainerApp/Accessor/Models/Users/SupportedLanguage.cs
+++ b/backend/ContainerApp/Accessor/Models/Users/SupportedLanguage.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Accessor.Models.Users;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum SupportedLanguage
+{
+    en, // English
+    he // Hebrew
+}

--- a/backend/ContainerApp/Accessor/Models/Users/UpdateUserModel.cs
+++ b/backend/ContainerApp/Accessor/Models/Users/UpdateUserModel.cs
@@ -6,4 +6,6 @@ public class UpdateUserModel
     public string? FirstName { get; set; }
     public string? LastName { get; set; }
     public string? Email { get; set; }
+    public SupportedLanguage? PreferredLanguageCode { get; set; }
+    public HebrewLevel? HebrewLevelValue { get; set; }
 }

--- a/backend/ContainerApp/Accessor/Models/Users/UserData.cs
+++ b/backend/ContainerApp/Accessor/Models/Users/UserData.cs
@@ -8,4 +8,6 @@ public class UserData
     public required string FirstName { get; set; }
     public required string LastName { get; set; }
     public required Role Role { get; set; }
+    public SupportedLanguage PreferredLanguageCode { get; set; }
+    public HebrewLevel? HebrewLevelValue { get; set; }
 }

--- a/backend/ContainerApp/Accessor/Models/Users/UserModel.cs
+++ b/backend/ContainerApp/Accessor/Models/Users/UserModel.cs
@@ -17,4 +17,10 @@ public class UserModel
 
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public required Role Role { get; set; }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public SupportedLanguage PreferredLanguageCode { get; set; }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public HebrewLevel? HebrewLevelValue { get; set; }
 }

--- a/backend/ContainerApp/Accessor/Services/AccessorService.cs
+++ b/backend/ContainerApp/Accessor/Services/AccessorService.cs
@@ -408,7 +408,9 @@ public class AccessorService : IAccessorService
                 Email = user.Email,
                 FirstName = user.FirstName,
                 LastName = user.LastName,
-                Role = user.Role
+                Role = user.Role,
+                PreferredLanguageCode = user.PreferredLanguageCode,
+                HebrewLevelValue = user.HebrewLevelValue
             };
     }
 
@@ -446,6 +448,16 @@ public class AccessorService : IAccessorService
         if (updateUser.Email is not null)
         {
             user.Email = updateUser.Email;
+        }
+
+        if (updateUser.PreferredLanguageCode is not null)
+        {
+            user.PreferredLanguageCode = updateUser.PreferredLanguageCode.Value;
+        }
+
+        if (updateUser.HebrewLevelValue is not null)
+        {
+            user.HebrewLevelValue = updateUser.HebrewLevelValue;
         }
 
         await _dbContext.SaveChangesAsync();
@@ -509,7 +521,9 @@ public class AccessorService : IAccessorService
                     Email = u.Email,
                     FirstName = u.FirstName,
                     LastName = u.LastName,
-                    Role = u.Role
+                    Role = u.Role,
+                    PreferredLanguageCode = u.PreferredLanguageCode,
+                    HebrewLevelValue = u.HebrewLevelValue
                 })
                 .ToListAsync();
 

--- a/backend/ContainerApp/Manager/Endpoints/UsersEndpoints.cs
+++ b/backend/ContainerApp/Manager/Endpoints/UsersEndpoints.cs
@@ -66,7 +66,9 @@ public static class UsersEndpoints
 
             // Detect UI language from Accept-Language header
             var acceptLanguage = httpContext.Request.Headers["Accept-Language"].FirstOrDefault();
-            logger.LogInformation("Raw Accept-Language header received: {Header}", acceptLanguage ?? "<null>");
+            var sanitizedAcceptLanguage = acceptLanguage?.Replace("\r", string.Empty).Replace("\n", string.Empty);
+            logger.LogInformation("Raw Accept-Language header received: {Header}", sanitizedAcceptLanguage ?? "<null>");
+
             var preferredLanguage = UserDefaultsHelper.ParsePreferredLanguage(acceptLanguage);
             logger.LogInformation("Parsed PreferredLanguageCode: {PreferredLanguage}", preferredLanguage);
 

--- a/backend/ContainerApp/Manager/Helpers/UserDefaultsHelper.cs
+++ b/backend/ContainerApp/Manager/Helpers/UserDefaultsHelper.cs
@@ -1,0 +1,38 @@
+using Manager.Models.Users;
+
+namespace Manager.Helpers;
+
+public static class UserDefaultsHelper
+{
+    /// <summary>
+    /// Parses an Accept-Language header into a SupportedLanguage enum.
+    /// Defaults to English if invalid or missing.
+    /// </summary>
+    public static SupportedLanguage ParsePreferredLanguage(string? header)
+    {
+        if (string.IsNullOrWhiteSpace(header))
+            return SupportedLanguage.en;
+
+        var first = header.Split(',').FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(first))
+            return SupportedLanguage.en;
+
+        // Handle values like "he-IL;q=0.9"
+        var lang = first.Split('-')[0].Split(';')[0].ToLowerInvariant();
+
+        return Enum.TryParse<SupportedLanguage>(lang, true, out var parsed)
+            ? parsed
+            : SupportedLanguage.en;
+    }
+
+    /// <summary>
+    /// Returns the default Hebrew level based on the user role.
+    /// Only students have a default value; others get null.
+    /// </summary>
+    public static HebrewLevel? GetDefaultHebrewLevel(Role role)
+    {
+        return role == Role.Student
+            ? HebrewLevel.beginner
+            : null;
+    }
+}

--- a/backend/ContainerApp/Manager/Models/Users/HebrewLevel.cs
+++ b/backend/ContainerApp/Manager/Models/Users/HebrewLevel.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Manager.Models.Users;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum HebrewLevel
+{
+    beginner,
+    intermediate,
+    advanced,
+    fluent
+}

--- a/backend/ContainerApp/Manager/Models/Users/SupportedLanguage.cs
+++ b/backend/ContainerApp/Manager/Models/Users/SupportedLanguage.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Manager.Models.Users;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum SupportedLanguage
+{
+    en, // English
+    he // Hebrew
+}

--- a/backend/ContainerApp/Manager/Models/Users/UpdateUserModel.cs
+++ b/backend/ContainerApp/Manager/Models/Users/UpdateUserModel.cs
@@ -6,4 +6,6 @@ public class UpdateUserModel
     public string? FirstName { get; set; }
     public string? LastName { get; set; }
     public string? Email { get; set; }
+    public SupportedLanguage? PreferredLanguageCode { get; set; }
+    public HebrewLevel? HebrewLevelValue { get; set; }
 }

--- a/backend/ContainerApp/Manager/Models/Users/UserData.cs
+++ b/backend/ContainerApp/Manager/Models/Users/UserData.cs
@@ -8,4 +8,6 @@ public class UserData
     public required string FirstName { get; set; }
     public required string LastName { get; set; }
     public required Role Role { get; set; }
+    public SupportedLanguage PreferredLanguageCode { get; set; } = SupportedLanguage.en;
+    public HebrewLevel? HebrewLevelValue { get; set; } // only for students
 }

--- a/backend/ContainerApp/Manager/Models/Users/UserModel.cs
+++ b/backend/ContainerApp/Manager/Models/Users/UserModel.cs
@@ -12,4 +12,6 @@ public class UserModel
 
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public Role Role { get; set; }
+    public SupportedLanguage PreferredLanguageCode { get; set; } = SupportedLanguage.en;
+    public HebrewLevel? HebrewLevelValue { get; set; } // only for students
 }


### PR DESCRIPTION
This PR introduces support for handling user language preferences and Hebrew proficiency levels in the system. It ensures that new users are automatically assigned a UI language based on their browser’s Accept-Language header, and that students are initialized with a default Hebrew level.