### PR TITLE
Alexandr/Refactor sentence endpoints to use DTO and validate user

### DIFF
--- a/backend/ContainerApp/Manager/Models/Sentences/SentenceRequest.cs
+++ b/backend/ContainerApp/Manager/Models/Sentences/SentenceRequest.cs
@@ -1,11 +1,17 @@
 ﻿namespace Manager.Models.Sentences;
 
+public sealed class SentenceRequestDto
+{
+    public Difficulty Difficulty { get; init; } = Difficulty.medium;
+    public bool Nikud { get; init; } = false;
+    public int Count { get; init; } = 1;
+}
 public sealed class SentenceRequest
 {
     public Difficulty Difficulty { get; init; } = Difficulty.medium;
     public bool Nikud { get; init; } = false;
     public int Count { get; init; } = 1;
-    public required Guid UserId { get; init; }
+    public Guid UserId { get; set; } = Guid.Empty;
 }
 public enum Difficulty
 {


### PR DESCRIPTION
Introduced SentenceRequestDto for incoming requests and moved user ID extraction and validation to the endpoints using HttpContext. The endpoints now construct SentenceRequest internally, ensuring the authenticated user's GUID is set correctly and improving request validation and security.