### PR TITLE
Shirley/633/add hebrew level and language

### DIFF
--- a/frontend/libs/app-providers/src/api/user/index.ts
+++ b/frontend/libs/app-providers/src/api/user/index.ts
@@ -5,13 +5,20 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { toast } from "react-toastify";
-import { apiClient as axios, toAppRole, User, UserDto } from "@app-providers";
+import {
+  apiClient as axios,
+  toAppRole,
+  User,
+  UserDto,
+  HebrewLevelValue,
+} from "@app-providers";
 
 interface UpdateUserInput {
   email?: string;
   firstName?: string;
   lastName?: string;
   role?: string;
+  hebrewLevelValue: HebrewLevelValue;
 }
 
 export const mapUser = (dto: UserDto): User => ({
@@ -20,6 +27,7 @@ export const mapUser = (dto: UserDto): User => ({
   firstName: dto.firstName,
   lastName: dto.lastName,
   role: toAppRole(dto.role),
+  hebrewLevelValue: dto.hebrewLevelValue,
 });
 
 export const USERS_URL = `${import.meta.env.VITE_USERS_URL}/user`;
@@ -58,12 +66,10 @@ export const updateUserByUserId = async (
   userId: string,
   userData: UpdateUserInput,
 ): Promise<User> => {
-  const body: Record<string, unknown> = { userId };
-  if (typeof userData.email === "string") body.email = userData.email;
-  if (typeof userData.firstName === "string")
-    body.firstName = userData.firstName;
-  if (typeof userData.lastName === "string") body.lastName = userData.lastName;
-  if (typeof userData.role === "string") body.role = userData.role;
+  const body = {
+    userId,
+    ...userData,
+  };
 
   const response = await axios.put(`${USERS_URL}/${userId}`, body);
   if (response.status !== 200) {
@@ -103,6 +109,7 @@ export const useUpdateUserByUserId = (
         lastName: updated.lastName,
         email: updated.email,
         role: existingUser?.role || "student", // Preserve the role or default to student
+        hebrewLevelValue: updated.hebrewLevelValue,
       };
       // Update the cache with the correct structure
       qc.setQueryData(["user", userId], updatedUserDto);

--- a/frontend/libs/app-providers/src/api/user/index.ts
+++ b/frontend/libs/app-providers/src/api/user/index.ts
@@ -11,6 +11,7 @@ import {
   User,
   UserDto,
   HebrewLevelValue,
+  PreferredLanguageCode,
 } from "@app-providers";
 
 interface UpdateUserInput {
@@ -19,6 +20,7 @@ interface UpdateUserInput {
   lastName?: string;
   role?: string;
   hebrewLevelValue: HebrewLevelValue;
+  preferredLanguageCode: PreferredLanguageCode;
 }
 
 export const mapUser = (dto: UserDto): User => ({
@@ -110,6 +112,7 @@ export const useUpdateUserByUserId = (
         email: updated.email,
         role: existingUser?.role || "student", // Preserve the role or default to student
         hebrewLevelValue: updated.hebrewLevelValue,
+        preferredLanguageCode: updated.preferredLanguageCode,
       };
       // Update the cache with the correct structure
       qc.setQueryData(["user", userId], updatedUserDto);

--- a/frontend/libs/app-providers/src/auth/provider/index.tsx
+++ b/frontend/libs/app-providers/src/auth/provider/index.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   AppRoleType,
   AuthContext,
@@ -22,6 +23,8 @@ const MIN_REFRESH_DELAY_MS = 5_000;
 const FALLBACK_TOKEN_EXPIRY_MS = 15 * 60 * 1000;
 
 export const AuthProvider = ({ children, appRole }: AuthProviderProps) => {
+  const { i18n } = useTranslation();
+
   const refreshTimerRef = useRef<number | null>(null);
   const refreshSkewMs = 60_000;
 
@@ -176,6 +179,17 @@ export const AuthProvider = ({ children, appRole }: AuthProviderProps) => {
     }
     clearRefreshTimer();
   }, [credentials, scheduleRefresh, clearRefreshTimer]);
+
+  // the backend takes automatically user's system's language when signing up
+  // theres also an option in the profile to select the preffered language
+  // so we update the i18n language when user data is loaded (the website will be in englsih / hebrew)
+  useEffect(() => {
+    const userLanguage = userData?.preferredLanguageCode || "en";
+
+    if (i18n.language !== userLanguage) {
+      i18n.changeLanguage(userLanguage);
+    }
+  }, [userData?.preferredLanguageCode, i18n]);
 
   return (
     <AuthContext.Provider

--- a/frontend/libs/app-providers/src/i18n/locale/en.json
+++ b/frontend/libs/app-providers/src/i18n/locale/en.json
@@ -319,6 +319,13 @@
       "admin": "Admin",
       "teacher": "Teacher",
       "student": "Student"
+    },
+    "hebrewLevels": {
+      "title": "Hebrew Level",
+      "beginner": "Beginner",
+      "intermediate": "Intermediate",
+      "advanced": "Advanced",
+      "fluent": "Fluent"
     }
   }
 }

--- a/frontend/libs/app-providers/src/i18n/locale/en.json
+++ b/frontend/libs/app-providers/src/i18n/locale/en.json
@@ -277,6 +277,7 @@
         "firstName": "First Name",
         "lastName": "Last Name",
         "email": "Email",
+        "preferredLanguage": "Preferred Language",
         "emailCannotBeChanged": "Email cannot be changed",
         "edit": "Edit",
         "saveChanges": "Save changes",
@@ -326,6 +327,10 @@
       "intermediate": "Intermediate",
       "advanced": "Advanced",
       "fluent": "Fluent"
+    },
+    "languages": {
+      "hebrew": "Hebrew",
+      "english": "English"
     }
   }
 }

--- a/frontend/libs/app-providers/src/i18n/locale/he.json
+++ b/frontend/libs/app-providers/src/i18n/locale/he.json
@@ -319,6 +319,13 @@
       "admin": "מנהל מערכת",
       "teacher": "מורה",
       "student": "תלמיד"
+    },
+    "hebrewLevels": {
+      "title": "רמת עברית",
+      "beginner": "מתחיל",
+      "intermediate": "בינוני",
+      "advanced": "מתקדם",
+      "fluent": "שוטף"
     }
   }
 }

--- a/frontend/libs/app-providers/src/i18n/locale/he.json
+++ b/frontend/libs/app-providers/src/i18n/locale/he.json
@@ -277,6 +277,7 @@
         "firstName": "שם פרטי",
         "lastName": "שם משפחה",
         "email": "דואר אלקטרוני",
+        "preferredLanguage": "שפה מועדפת",
         "emailCannotBeChanged": "דואר אלקטרוני לא ניתן לשינוי",
         "edit": "עריכה",
         "saveChanges": "שמור שינויים",
@@ -326,6 +327,10 @@
       "intermediate": "בינוני",
       "advanced": "מתקדם",
       "fluent": "שוטף"
+    },
+    "languages": {
+      "hebrew": "עברית",
+      "english": "אנגלית"
     }
   }
 }

--- a/frontend/libs/app-providers/src/types/user/index.ts
+++ b/frontend/libs/app-providers/src/types/user/index.ts
@@ -21,7 +21,13 @@ export type UserDto = User & {
   role?: AppRoleType;
 };
 
-export type HebrewLevelValue = "beginner" | "intermediate" | "advanced" | "fluent";
+export type HebrewLevelValue =
+  | "beginner"
+  | "intermediate"
+  | "advanced"
+  | "fluent";
+
+export type PreferredLanguageCode = "he" | "en";
 
 export interface User {
   userId: string;
@@ -29,6 +35,6 @@ export interface User {
   lastName: string;
   email: string;
   role: AppRoleType;
-  preferredLanguageCode?: string;
+  preferredLanguageCode?: PreferredLanguageCode;
   hebrewLevelValue?: HebrewLevelValue;
 }

--- a/frontend/libs/app-providers/src/types/user/index.ts
+++ b/frontend/libs/app-providers/src/types/user/index.ts
@@ -21,10 +21,14 @@ export type UserDto = User & {
   role?: AppRoleType;
 };
 
+export type HebrewLevelValue = "beginner" | "intermediate" | "advanced" | "fluent";
+
 export interface User {
   userId: string;
   firstName: string;
   lastName: string;
   email: string;
   role: AppRoleType;
+  preferredLanguageCode?: string;
+  hebrewLevelValue?: HebrewLevelValue;
 }

--- a/frontend/libs/ui/components/src/Profile/index.tsx
+++ b/frontend/libs/ui/components/src/Profile/index.tsx
@@ -1,9 +1,14 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Typography, TextField, Stack } from "@mui/material";
-import { useUpdateUserByUserId, User } from "@app-providers";
-import { Button } from "../Button";
+import {
+  useUpdateUserByUserId,
+  User,
+  HebrewLevelValue,
+  toAppRole,
+} from "@app-providers";
 import { useStyles } from "./style";
+import { Dropdown, Button } from "@ui-components";
 
 export const Profile = ({ user }: { user: User }) => {
   const { t, i18n } = useTranslation();
@@ -17,16 +22,18 @@ export const Profile = ({ user }: { user: User }) => {
   const [userDetails, setUserDetails] = useState({
     firstName: user?.firstName ?? "",
     lastName: user?.lastName ?? "",
+    hebrewLevelValue: user?.hebrewLevelValue ?? "beginner",
   });
 
   useEffect(() => {
     setUserDetails({
       firstName: user?.firstName ?? "",
       lastName: user?.lastName ?? "",
+      hebrewLevelValue: user?.hebrewLevelValue ?? "beginner",
     });
-  }, [user?.firstName, user?.lastName, user?.userId]);
+  }, [user?.firstName, user?.hebrewLevelValue, user?.lastName, user.userId]);
 
-  const handleChange =
+  const handleTextChange =
     (field: "firstName" | "lastName") =>
     (e: React.ChangeEvent<HTMLInputElement>) => {
       setUserDetails((prev) => ({
@@ -35,10 +42,18 @@ export const Profile = ({ user }: { user: User }) => {
       }));
     };
 
+  const handleDropdownChange = (field: "hebrewLevelValue") => (val: string) => {
+    setUserDetails((prev) => ({
+      ...prev,
+      [field]: val as HebrewLevelValue,
+    }));
+  };
+
   const handleCancel = () => {
     setUserDetails({
       firstName: user?.firstName ?? "",
       lastName: user?.lastName ?? "",
+      hebrewLevelValue: user?.hebrewLevelValue ?? "beginner",
     });
   };
 
@@ -47,12 +62,21 @@ export const Profile = ({ user }: { user: User }) => {
       email: user.email,
       firstName: userDetails.firstName.trim(),
       lastName: userDetails.lastName.trim(),
+      hebrewLevelValue: userDetails.hebrewLevelValue,
     });
   };
 
   const dirty =
     userDetails.firstName.trim() !== (user?.firstName ?? "").trim() ||
-    userDetails.lastName.trim() !== (user?.lastName ?? "").trim();
+    userDetails.lastName.trim() !== (user?.lastName ?? "").trim() ||
+    userDetails.hebrewLevelValue !== (user?.hebrewLevelValue ?? "beginner");
+
+  const hebrewLevelOptions = [
+    { value: "beginner", label: t("hebrewLevels.beginner") },
+    { value: "intermediate", label: t("hebrewLevels.intermediate") },
+    { value: "advanced", label: t("hebrewLevels.advanced") },
+    { value: "fluent", label: t("hebrewLevels.fluent") },
+  ];
 
   return (
     <div className={classes.container}>
@@ -81,7 +105,7 @@ export const Profile = ({ user }: { user: User }) => {
             </Typography>
             <TextField
               value={userDetails.firstName}
-              onChange={handleChange("firstName")}
+              onChange={handleTextChange("firstName")}
               fullWidth
               className={isRTL ? classes.textFieldRTL : classes.textFieldLTR}
             />
@@ -97,7 +121,7 @@ export const Profile = ({ user }: { user: User }) => {
             </Typography>
             <TextField
               value={userDetails.lastName}
-              onChange={handleChange("lastName")}
+              onChange={handleTextChange("lastName")}
               fullWidth
               className={isRTL ? classes.textFieldRTL : classes.textFieldLTR}
             />
@@ -111,6 +135,29 @@ export const Profile = ({ user }: { user: User }) => {
                 isRTL ? classes.emailFieldLabelRTL : classes.emailFieldLabelLTR
               }
             >
+              {/* Conditionally render Hebrew Level for student role */}
+              {toAppRole(user?.role) === "student" && (
+                <div className={classes.fieldContainer}>
+                  <Typography
+                    variant="body2"
+                    color="text.primary"
+                    className={
+                      isRTL ? classes.fieldLabelRTL : classes.fieldLabelLTR
+                    }
+                  >
+                    {t("hebrewLevels.title")}
+                  </Typography>
+                  <Dropdown
+                    name="hebrewLevel"
+                    options={hebrewLevelOptions}
+                    value={userDetails.hebrewLevelValue}
+                    onChange={(val) =>
+                      handleDropdownChange("hebrewLevelValue")(val)
+                    }
+                  />
+                </div>
+              )}
+
               {t("pages.profile.email")}
             </Typography>
             <TextField

--- a/frontend/libs/ui/components/src/Profile/index.tsx
+++ b/frontend/libs/ui/components/src/Profile/index.tsx
@@ -1,12 +1,12 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Typography, TextField, Stack } from "@mui/material";
+import { useUpdateUserByUserId, toAppRole } from "@app-providers";
 import {
-  useUpdateUserByUserId,
   User,
   HebrewLevelValue,
-  toAppRole,
-} from "@app-providers";
+  PreferredLanguageCode,
+} from "@app-providers/types";
 import { useStyles } from "./style";
 import { Dropdown, Button } from "@ui-components";
 
@@ -23,6 +23,7 @@ export const Profile = ({ user }: { user: User }) => {
     firstName: user?.firstName ?? "",
     lastName: user?.lastName ?? "",
     hebrewLevelValue: user?.hebrewLevelValue ?? "beginner",
+    preferredLanguageCode: user?.preferredLanguageCode ?? "en",
   });
 
   useEffect(() => {
@@ -30,8 +31,15 @@ export const Profile = ({ user }: { user: User }) => {
       firstName: user?.firstName ?? "",
       lastName: user?.lastName ?? "",
       hebrewLevelValue: user?.hebrewLevelValue ?? "beginner",
+      preferredLanguageCode: user?.preferredLanguageCode ?? "en",
     });
-  }, [user?.firstName, user?.hebrewLevelValue, user?.lastName, user.userId]);
+  }, [
+    user?.firstName,
+    user?.hebrewLevelValue,
+    user?.lastName,
+    user?.preferredLanguageCode,
+    user.userId,
+  ]);
 
   const handleTextChange =
     (field: "firstName" | "lastName") =>
@@ -49,11 +57,19 @@ export const Profile = ({ user }: { user: User }) => {
     }));
   };
 
+  const handleLanguageChange = (val: string) => {
+    setUserDetails((prev) => ({
+      ...prev,
+      preferredLanguageCode: val as PreferredLanguageCode,
+    }));
+  };
+
   const handleCancel = () => {
     setUserDetails({
       firstName: user?.firstName ?? "",
       lastName: user?.lastName ?? "",
       hebrewLevelValue: user?.hebrewLevelValue ?? "beginner",
+      preferredLanguageCode: user?.preferredLanguageCode ?? "en",
     });
   };
 
@@ -63,19 +79,26 @@ export const Profile = ({ user }: { user: User }) => {
       firstName: userDetails.firstName.trim(),
       lastName: userDetails.lastName.trim(),
       hebrewLevelValue: userDetails.hebrewLevelValue,
+      preferredLanguageCode: userDetails.preferredLanguageCode,
     });
   };
 
   const dirty =
     userDetails.firstName.trim() !== (user?.firstName ?? "").trim() ||
     userDetails.lastName.trim() !== (user?.lastName ?? "").trim() ||
-    userDetails.hebrewLevelValue !== (user?.hebrewLevelValue ?? "beginner");
+    userDetails.hebrewLevelValue !== (user?.hebrewLevelValue ?? "beginner") ||
+    userDetails.preferredLanguageCode !== (user?.preferredLanguageCode ?? "en");
 
   const hebrewLevelOptions = [
     { value: "beginner", label: t("hebrewLevels.beginner") },
     { value: "intermediate", label: t("hebrewLevels.intermediate") },
     { value: "advanced", label: t("hebrewLevels.advanced") },
     { value: "fluent", label: t("hebrewLevels.fluent") },
+  ];
+
+  const languageOptions = [
+    { value: "he", label: t("languages.hebrew") },
+    { value: "en", label: t("languages.english") },
   ];
 
   return (
@@ -157,6 +180,24 @@ export const Profile = ({ user }: { user: User }) => {
                   />
                 </div>
               )}
+
+              <div className={classes.fieldContainer}>
+                <Typography
+                  variant="body2"
+                  color="text.primary"
+                  className={
+                    isRTL ? classes.fieldLabelRTL : classes.fieldLabelLTR
+                  }
+                >
+                  {t("pages.profile.preferredLanguage")}
+                </Typography>
+                <Dropdown
+                  name="preferredLanguage"
+                  options={languageOptions}
+                  value={userDetails.preferredLanguageCode}
+                  onChange={handleLanguageChange}
+                />
+              </div>
 
               {t("pages.profile.email")}
             </Typography>


### PR DESCRIPTION
#633 
- when a user signs up, the backend automatically takes his system's language (hebrew or english) and sets it to user's preffered language, so i added a dropdown in the profile so the user can select his language preference and it will affect i18n translation
- a user now have the option to select his hebrew level 
<img width="1913" height="895" alt="image" src="https://github.com/user-attachments/assets/caf8b15a-6fe5-431f-9dee-236f59f0f759" />
<img width="1911" height="902" alt="image" src="https://github.com/user-attachments/assets/6c53536a-3214-45e4-a479-0b8b6d1769d7" />
<img width="1913" height="907" alt="image" src="https://github.com/user-attachments/assets/af26332d-a62d-4739-8a3e-349da0a5ed8d" />
