### PR TITLE
Daniel Strauss/714/Update DotQueue package and refactor queue handlers

### DIFF
--- a/backend/ContainerApp/Accessor/Accessor.csproj
+++ b/backend/ContainerApp/Accessor/Accessor.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
 	<PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
-	<PackageReference Include="DotQueue" Version="1.0.1" />
+	<PackageReference Include="DotQueue" Version="1.0.5" />
 	<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Dapr.AspNetCore" Version="1.15.4" />

--- a/backend/ContainerApp/Engine/Endpoints/EngineQueueHandler.cs
+++ b/backend/ContainerApp/Engine/Endpoints/EngineQueueHandler.cs
@@ -15,16 +15,23 @@ using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace Engine.Endpoints;
 
-public class EngineQueueHandler : IQueueHandler<Message>
+public class EngineQueueHandler : RoutedQueueHandler<Message, MessageAction>
 {
     private readonly DaprClient _daprClient;
     private readonly ILogger<EngineQueueHandler> _logger;
-    private readonly Dictionary<MessageAction, Func<Message, Func<Task>, CancellationToken, Task>> _handlers;
     private readonly IChatAiService _aiService;
     private readonly ISentencesService _sentencesService;
     private readonly IAiReplyPublisher _publisher;
     private readonly IAccessorClient _accessorClient;
     private readonly IChatTitleService _chatTitleService;
+    protected override MessageAction GetAction(Message message) => message.ActionName;
+
+    protected override void Configure(RouteBuilder routes) => routes
+        .On(MessageAction.CreateTask, HandleCreateTaskAsync)
+        .On(MessageAction.TestLongTask, HandleTestLongTaskAsync)
+        .On(MessageAction.ProcessingChatMessage, HandleProcessingChatMessageAsync)
+        .On(MessageAction.GenerateSentences, HandleSentenceGenerationAsync)
+        .On(MessageAction.GenerateSplitSentences, HandleSentenceGenerationAsync);
 
     public EngineQueueHandler(
         DaprClient daprClient,
@@ -33,7 +40,7 @@ public class EngineQueueHandler : IQueueHandler<Message>
         IAccessorClient accessorClient,
         ISentencesService sentencesService,
         IChatTitleService chatTitleService,
-        ILogger<EngineQueueHandler> logger)
+        ILogger<EngineQueueHandler> logger) : base(logger)
     {
         _daprClient = daprClient;
         _aiService = aiService;
@@ -42,31 +49,9 @@ public class EngineQueueHandler : IQueueHandler<Message>
         _chatTitleService = chatTitleService;
         _logger = logger;
         _sentencesService = sentencesService;
-        _handlers = new Dictionary<MessageAction, Func<Message, Func<Task>, CancellationToken, Task>>
-        {
-            [MessageAction.CreateTask] = HandleCreateTaskAsync,
-            [MessageAction.TestLongTask] = HandleTestLongTaskAsync,
-            [MessageAction.ProcessingChatMessage] = HandleProcessingChatMessageAsync,
-            [MessageAction.GenerateSentences] = HandleSentenceGenerationAsync,
-            [MessageAction.GenerateSplitSentences] = HandleSentenceGenerationAsync
-
-        };
     }
 
-    public async Task HandleAsync(Message message, Func<Task> renewLock, CancellationToken cancellationToken)
-    {
-        if (_handlers.TryGetValue(message.ActionName, out var handler))
-        {
-            await handler(message, renewLock, cancellationToken);
-        }
-        else
-        {
-            _logger.LogWarning("No handler for action {Action}", message.ActionName);
-            throw new NonRetryableException($"No handler for action {message.ActionName}");
-        }
-    }
-
-    private async Task HandleCreateTaskAsync(Message message, Func<Task> renewLock, CancellationToken cancellationToken)
+    private async Task HandleCreateTaskAsync(Message message, IReadOnlyDictionary<string, string>? metadata, Func<Task> renewLock, CancellationToken cancellationToken)
     {
         try
         {
@@ -108,7 +93,7 @@ public class EngineQueueHandler : IQueueHandler<Message>
         }
     }
 
-    private async Task HandleTestLongTaskAsync(Message message, Func<Task> renewLock, CancellationToken cancellationToken)
+    private async Task HandleTestLongTaskAsync(Message message, IReadOnlyDictionary<string, string>? metadata, Func<Task> renewLock, CancellationToken cancellationToken)
     {
         using var renewalCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         var renewalTask = Task.Run(async () =>
@@ -175,10 +160,7 @@ public class EngineQueueHandler : IQueueHandler<Message>
         }
     }
 
-    private async Task HandleProcessingChatMessageAsync(
-           Message message,
-           Func<Task> renewLock,
-           CancellationToken ct)
+    private async Task HandleProcessingChatMessageAsync(Message message, IReadOnlyDictionary<string, string>? metadata, Func<Task> renewLock, CancellationToken ct)
     {
         long getHistoryTime = 0;
         long addOrCheckSystemPromptTime = 0;
@@ -386,7 +368,7 @@ public class EngineQueueHandler : IQueueHandler<Message>
         }
     }
 
-    private async Task HandleSentenceGenerationAsync(Message message, Func<Task> renewLock, CancellationToken cancellationToken)
+    private async Task HandleSentenceGenerationAsync(Message message, IReadOnlyDictionary<string, string>? metadata, Func<Task> renewLock, CancellationToken cancellationToken)
     {
         try
         {

--- a/backend/ContainerApp/Engine/Engine.csproj
+++ b/backend/ContainerApp/Engine/Engine.csproj
@@ -13,7 +13,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Dapr.AspNetCore" Version="1.15.4" />
-		<PackageReference Include="DotQueue" Version="1.0.1" />
+		<PackageReference Include="DotQueue" Version="1.0.5" />
 		<PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.45.0" />
 		<PackageReference Include="Polly" Version="8.6.3" />
 		<PackageReference Include="Microsoft.SemanticKernel" Version="1.63.0" />

--- a/backend/ContainerApp/Manager/Manager.csproj
+++ b/backend/ContainerApp/Manager/Manager.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
 	<PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
-	<PackageReference Include="DotQueue" Version="1.0.3" />
+	<PackageReference Include="DotQueue" Version="1.0.5" />
 	<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Dapr.Actors.AspNetCore" Version="1.15.4" />

--- a/backend/ContainerApp/UnitTests/AccessorUnitTests/ApprovalTests/AccessorQueueHandler_Invalid_Approval.cs
+++ b/backend/ContainerApp/UnitTests/AccessorUnitTests/ApprovalTests/AccessorQueueHandler_Invalid_Approval.cs
@@ -25,7 +25,7 @@ public class AccessorQueueHandler_Invalid_Approval
         Exception? ex = null;
         try
         {
-            await handler.HandleAsync(msg, () => Task.CompletedTask, CancellationToken.None);
+            await handler.HandleAsync(msg, null, () => Task.CompletedTask, CancellationToken.None);
         }
         catch (Exception e)
         {

--- a/backend/ContainerApp/UnitTests/AccessorUnitTests/ApprovalTests/Approvals/AccessorQueueHandler_Invalid_Approval.Invalid_Message_Shapes_ErrorContract_Is_Approved.QueueHandler_UnknownAction.approved.json
+++ b/backend/ContainerApp/UnitTests/AccessorUnitTests/ApprovalTests/Approvals/AccessorQueueHandler_Invalid_Approval.Invalid_Message_Shapes_ErrorContract_Is_Approved.QueueHandler_UnknownAction.approved.json
@@ -4,6 +4,6 @@
     
   "exceptionType":  "DotQueue.NonRetryableException",
     
-  "message":  "No handler for action 9999"
+  "message":  "No handler registered for action 9999"
 
 }

--- a/backend/ContainerApp/UnitTests/AccessorUnitTests/Endpoints/AccessorQueueHandlerTests.cs
+++ b/backend/ContainerApp/UnitTests/AccessorUnitTests/Endpoints/AccessorQueueHandlerTests.cs
@@ -46,7 +46,7 @@ public class AccessorQueueHandlerTests
         var renewed = false;
         Func<Task> renew = () => { renewed = true; return Task.CompletedTask; };
 
-        await handler.HandleAsync(msg, renew, CancellationToken.None);
+        await handler.HandleAsync(msg, null, renew, CancellationToken.None);
 
         renewed.Should().BeFalse(); // ensure renew lock not called
         taskSvc.VerifyAll();
@@ -62,7 +62,7 @@ public class AccessorQueueHandlerTests
         var log = Log();
         var handler = new AccessorQueueHandler(taskSvc.Object, pub.Object, log.Object);
 
-        Func<Task> act = () => handler.HandleAsync(msg, () => Task.CompletedTask, CancellationToken.None);
+        Func<Task> act = () => handler.HandleAsync(msg, null, () => Task.CompletedTask, CancellationToken.None);
 
         await act.Should().ThrowAsync<NonRetryableException>()
                  .WithMessage($"*{expectedMessagePart}*");
@@ -80,7 +80,7 @@ public class AccessorQueueHandlerTests
                 ActionName = (MessageAction)9999,
                 Payload = JsonDocument.Parse("{}").RootElement
             },
-            "No handler for action"
+            "No handler registered for action"
         };
         yield return new object[]
         {
@@ -107,7 +107,7 @@ public class AccessorQueueHandlerTests
             Payload = JsonDocument.Parse("null").RootElement
         };
 
-        Func<Task> act = () => handler.HandleAsync(msg, () => Task.CompletedTask, CancellationToken.None);
+        Func<Task> act = () => handler.HandleAsync(msg, null, () => Task.CompletedTask, CancellationToken.None);
 
         await act.Should().ThrowAsync<NonRetryableException>()
                  .WithMessage("*Payload deserialization returned null*TaskModel*");


### PR DESCRIPTION
- Bump `DotQueue` package version from `1.0.1` to `1.0.5` in `Accessor.csproj`, `Engine.csproj`, and `Manager.csproj`.
- Refactor `AccessorQueueHandler`, `EngineQueueHandler`, and `ManagerQueueHandler` to remove `_handlers` dictionary and implement route configuration methods.
- Modify `HandleAsync` methods to accept an optional `metadata` parameter, enhancing metadata handling.
- Update unit tests to align with new method signatures and improve error message clarity regarding action handlers.