### PR TITLE
Snir/734/refactor acr tagging to prevent digest conflicts between environments

### DIFF
--- a/.github/workflows/acr-purge.yml
+++ b/.github/workflows/acr-purge.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Purge old tags for ${{ matrix.repo }}
         run: |
           REPO="${{ matrix.repo }}"
-          KEEP_ALWAYS=("latest" "dev" "prod" "stage")
+          KEEP_ALWAYS=("latest" "dev" "prod" "stage" "test")
 
           echo "Cleaning repo: $REPO"
 

--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -95,7 +95,6 @@ jobs:
             fi
             # Always add these two tags
             echo "${IMAGE_NAME}:${ENV_TAG}-${SHORT_SHA}"
-            echo "${IMAGE_NAME}:${ENV_TAG}"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -25,10 +25,13 @@ jobs:
     steps:
       - name: Set image tag
         id: set-tag
+        env:
+          ENV_TAG: ${{ inputs.environment_name }}
         run: |
           SHORT_SHA="${{ github.sha }}"
           SHORT_SHA="${SHORT_SHA:0:7}"
-          echo "image_tag=${SHORT_SHA}" >> $GITHUB_OUTPUT
+          FULL_TAG="${ENV_TAG}-${SHORT_SHA}"
+          echo "image_tag=${FULL_TAG}" >> $GITHUB_OUTPUT
 
   build_and_push:
     needs: generate_tag

--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -95,6 +95,7 @@ jobs:
             fi
             # Always add these two tags
             echo "${IMAGE_NAME}:${ENV_TAG}-${SHORT_SHA}"
+            echo "${IMAGE_NAME}:${ENV_TAG}"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -91,7 +91,7 @@ jobs:
               echo "${IMAGE_NAME}:latest"
             fi
             # Always add these two tags
-            echo "${IMAGE_NAME}:${SHORT_SHA}"
+            echo "${IMAGE_NAME}:${ENV_TAG}-${SHORT_SHA}"
             echo "${IMAGE_NAME}:${ENV_TAG}"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
updates the ACR image tagging strategy to avoid digest conflicts between environments.
Previously, both dev:<commit-hash> and stage:<commit-hash> pointed to the same digest, which caused issues when ACR purge tasks ran - one environment tag could become detached, and the digest was sometimes deleted even though it was still needed.