### PR TITLE
adding fixture to user tests

### DIFF
--- a/backend/IntegrationTest/Fixtures/PerTestUserFixture.cs
+++ b/backend/IntegrationTest/Fixtures/PerTestUserFixture.cs
@@ -1,0 +1,81 @@
+using IntegrationTests.Constants;
+using IntegrationTests.Models.Auth;
+using Manager.Models.Auth;
+using Manager.Models.Users;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace IntegrationTests.Fixtures;
+
+public class PerTestUserFixture : IAsyncLifetime
+{
+    private readonly HttpTestFixture _httpFixture;
+
+    public HttpTestFixture HttpFixture => _httpFixture;
+    public HttpClient Client => _httpFixture.Client;
+
+    private readonly List<Guid> _createdUserIds = new();
+
+    public PerTestUserFixture()
+    {
+        _httpFixture = new HttpTestFixture();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        foreach (var id in _createdUserIds)
+        {
+            try { await Client.DeleteAsync(UserRoutes.UserById(id)); } catch { }
+        }
+
+        _httpFixture.Dispose();
+    }
+
+    /// <summary>
+    /// Creates a new user with the given role, logs in, sets the bearer token,
+    /// and returns the created user as UserData.
+    /// </summary>
+    public async Task<UserData> CreateAndLoginAsync(Role role, string? email = null)
+    {
+        var newUser = new UserModel
+        {
+            UserId = Guid.NewGuid(),
+            Email = email ?? $"test-{Guid.NewGuid():N}@example.com",
+            Password = "Test123!",
+            FirstName = "PerTest",
+            LastName = "User",
+            Role = role
+        };
+
+        var createRes = await Client.PostAsJsonAsync(UserRoutes.UserBase, newUser);
+        createRes.EnsureSuccessStatusCode();
+
+        _createdUserIds.Add(newUser.UserId);
+
+        // login
+        var loginReq = new LoginRequest { Email = newUser.Email, Password = newUser.Password };
+        var loginRes = await Client.PostAsJsonAsync(AuthRoutes.Login, loginReq);
+        loginRes.EnsureSuccessStatusCode();
+
+        var body = await loginRes.Content.ReadAsStringAsync();
+        var tokenRes = JsonSerializer.Deserialize<AccessTokenResponse>(body)
+                       ?? throw new InvalidOperationException("Invalid login response");
+
+        Client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", tokenRes.AccessToken);
+
+        return new UserData
+        {
+            UserId = newUser.UserId,
+            Email = newUser.Email,
+            FirstName = newUser.FirstName,
+            LastName = newUser.LastName,
+            Role = newUser.Role,
+            PreferredLanguageCode = SupportedLanguage.en,
+            HebrewLevelValue = HebrewLevel.beginner
+        };
+    }
+}

--- a/backend/IntegrationTest/Fixtures/SharedTestCollection.cs
+++ b/backend/IntegrationTest/Fixtures/SharedTestCollection.cs
@@ -5,3 +5,8 @@ public class SharedTestCollection
     : ICollectionFixture<SharedTestFixture>,
       ICollectionFixture<SignalRTestFixture>
 { }
+
+[CollectionDefinition("Per-test user collection")]
+public class PerTestUserCollection
+    : ICollectionFixture<PerTestUserFixture>
+{ }

--- a/backend/IntegrationTest/Tests/Users/TeacherStudentIntegrationTests.cs
+++ b/backend/IntegrationTest/Tests/Users/TeacherStudentIntegrationTests.cs
@@ -1,166 +1,148 @@
 ﻿using System.Net;
 using System.Net.Http.Json;
-using System.Text.Json;
 using FluentAssertions;
 using IntegrationTests.Constants;
 using IntegrationTests.Fixtures;
-using IntegrationTests.Models.Auth;
-using Manager.Models.Auth;
 using Manager.Models.Users;
 using Xunit.Abstractions;
 
 namespace IntegrationTests.Tests.Users;
 
-[Collection("Shared test collection")]
+[Collection("Per-test user collection")]
 public class TeacherStudentIntegrationTests : IAsyncLifetime
 {
-    private readonly SharedTestFixture _shared;
+    private readonly PerTestUserFixture _perUser;
     private readonly HttpClient _client;
     private readonly ITestOutputHelper _output;
-    private readonly TestUserHelper _users;
 
-    public TeacherStudentIntegrationTests(SharedTestFixture sharedFixture, ITestOutputHelper output)
+    public TeacherStudentIntegrationTests(PerTestUserFixture perUserFixture, ITestOutputHelper output)
     {
-        _shared = sharedFixture;
-        _client = sharedFixture.HttpFixture.Client;
+        _perUser = perUserFixture;
+        _client = perUserFixture.Client;
         _output = output;
-        _users = new TestUserHelper(_client);
     }
 
-    public async Task InitializeAsync()
-    {
-        await _shared.GetAuthenticatedTokenAsync(attachToHttpClient: true);
-    }
-
+    public Task InitializeAsync() => Task.CompletedTask;
     public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact(DisplayName = "Admin can assign & unassign any student to any teacher")]
     public async Task Admin_Assign_Unassign_Flow()
     {
-        // Create teacher & student
-        var teacherId = await _users.CreateUserAsync(Role.Teacher);
-        var studentId = await _users.CreateUserAsync(Role.Student);
+        // Login as Admin
+        await _perUser.CreateAndLoginAsync(Role.Admin);
+
+        // Create teacher & student as Admin (no login switch)
+        var teacher = TestDataHelper.CreateUser(role: "teacher");
+        var student = TestDataHelper.CreateUser(role: "student");
+
+        (await _client.PostAsJsonAsync(UserRoutes.UserBase, teacher)).EnsureSuccessStatusCode();
+        (await _client.PostAsJsonAsync(UserRoutes.UserBase, student)).EnsureSuccessStatusCode();
 
         // Assign
-        var assign = await _client.PostAsync(MappingRoutes.Assign(teacherId, studentId), content: null);
+        var assign = await _client.PostAsync(MappingRoutes.Assign(teacher.UserId, student.UserId), null);
         assign.StatusCode.Should().Be(HttpStatusCode.OK);
 
         // Idempotent assign
-        var assign2 = await _client.PostAsync(MappingRoutes.Assign(teacherId, studentId), content: null);
+        var assign2 = await _client.PostAsync(MappingRoutes.Assign(teacher.UserId, student.UserId), null);
         assign2.StatusCode.Should().Be(HttpStatusCode.OK);
 
         // List students (admin can list any)
-        var list = await _client.GetAsync(MappingRoutes.ListStudents(teacherId));
+        var list = await _client.GetAsync(MappingRoutes.ListStudents(teacher.UserId));
         list.StatusCode.Should().Be(HttpStatusCode.OK);
         var students = await list.Content.ReadFromJsonAsync<List<UserData>>() ?? new();
-        students.Should().Contain(s => s.UserId == studentId);
+        students.Should().Contain(s => s.UserId == student.UserId);
 
         // Unassign
-        var unassign = await _client.DeleteAsync(MappingRoutes.Unassign(teacherId, studentId));
+        var unassign = await _client.DeleteAsync(MappingRoutes.Unassign(teacher.UserId, student.UserId));
         unassign.StatusCode.Should().Be(HttpStatusCode.OK);
 
         // Idempotent unassign
-        var unassign2 = await _client.DeleteAsync(MappingRoutes.Unassign(teacherId, studentId));
+        var unassign2 = await _client.DeleteAsync(MappingRoutes.Unassign(teacher.UserId, student.UserId));
         unassign2.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        await _users.CleanupUser(studentId);
-        await _users.CleanupUser(teacherId);
     }
 
     [Fact(DisplayName = "Teacher can assign/unassign only to self; forbidden for other teachers")]
     public async Task Teacher_Can_Only_Manage_Self()
     {
-        var (t1Id, t1Email, t1Pwd) = await _users.CreateAndLogin(Role.Teacher);
-        var t2Id = await _users.CreateUserAsync(Role.Teacher);
-        var s1Id = await _users.CreateUserAsync(Role.Student);
+        // Login as Teacher1 (active actor)
+        var teacher1 = await _perUser.CreateAndLoginAsync(Role.Teacher);
 
-        var t1Token = await _users.LoginAndGetTokenAsync(t1Email, t1Pwd);
-        _users.UseBearer(t1Token);
+        // Create Teacher2 + Student via Teacher1 token
+        var teacher2 = TestDataHelper.CreateUser(role: "teacher");
+        var student = TestDataHelper.CreateUser(role: "student");
 
-        var okAssignSelf = await _client.PostAsync(MappingRoutes.Assign(t1Id, s1Id), null);
+        (await _client.PostAsJsonAsync(UserRoutes.UserBase, teacher2)).EnsureSuccessStatusCode();
+        (await _client.PostAsJsonAsync(UserRoutes.UserBase, student)).EnsureSuccessStatusCode();
+
+        // Teacher1 can assign/unassign to self
+        var okAssignSelf = await _client.PostAsync(MappingRoutes.Assign(teacher1.UserId, student.UserId), null);
         okAssignSelf.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var forbidAssignOther = await _client.PostAsync(MappingRoutes.Assign(t2Id, s1Id), null);
+        var forbidAssignOther = await _client.PostAsync(MappingRoutes.Assign(teacher2.UserId, student.UserId), null);
         forbidAssignOther.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var okUnassignSelf = await _client.DeleteAsync(MappingRoutes.Unassign(t1Id, s1Id));
+        var okUnassignSelf = await _client.DeleteAsync(MappingRoutes.Unassign(teacher1.UserId, student.UserId));
         okUnassignSelf.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var forbidUnassignOther = await _client.DeleteAsync(MappingRoutes.Unassign(t2Id, s1Id));
+        var forbidUnassignOther = await _client.DeleteAsync(MappingRoutes.Unassign(teacher2.UserId, student.UserId));
         forbidUnassignOther.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var okListSelf = await _client.GetAsync(MappingRoutes.ListStudents(t1Id));
+        // List students
+        var okListSelf = await _client.GetAsync(MappingRoutes.ListStudents(teacher1.UserId));
         okListSelf.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var forbidListOther = await _client.GetAsync(MappingRoutes.ListStudents(t2Id));
+        var forbidListOther = await _client.GetAsync(MappingRoutes.ListStudents(teacher2.UserId));
         forbidListOther.StatusCode.Should().Be(HttpStatusCode.Forbidden);
-
-        var adminToken = await _shared.GetAuthenticatedTokenAsync(attachToHttpClient: false);
-        _users.UseBearer(adminToken);
-
-        await _users.CleanupUser(s1Id);
-        await _users.CleanupUser(t2Id);
-        await _users.CleanupUser(t1Id);
     }
 
     [Fact(DisplayName = "Student cannot access mapping endpoints")]
     public async Task Student_Cannot_Access_Mapping_Endpoints()
     {
-        // Create a student user and login
-        var s = TestUserHelper.NewUser(Role.Student);
-        var res = await _client.PostAsJsonAsync(UserRoutes.UserBase, s);
-        res.EnsureSuccessStatusCode();
-        var sToken = await _users.LoginAndGetTokenAsync(s.Email, s.Password);
-        _users.UseBearer(sToken);
+        // Login as Student (active actor)
+        var student = await _perUser.CreateAndLoginAsync(Role.Student);
 
-        // Create a teacher + another student (using Admin token)
-        var adminToken = await _shared.GetAuthenticatedTokenAsync(attachToHttpClient: false);
-        _users.UseBearer(adminToken);
-        var teacherId = await _users.CreateUserAsync(Role.Teacher);
-        var studentId = await _users.CreateUserAsync(Role.Student);
+        // Create Teacher + another Student via Student’s token
+        var teacher = TestDataHelper.CreateUser(role: "teacher");
+        var anotherStudent = TestDataHelper.CreateUser(role: "student");
 
-        // Use student token to try calling endpoints
-        _users.UseBearer(sToken);
+        (await _client.PostAsJsonAsync(UserRoutes.UserBase, teacher)).EnsureSuccessStatusCode();
+        (await _client.PostAsJsonAsync(UserRoutes.UserBase, anotherStudent)).EnsureSuccessStatusCode();
 
-        var r1 = await _client.GetAsync(MappingRoutes.ListStudents(teacherId));
-        r1.StatusCode.Should().Be(HttpStatusCode.Forbidden); // policy AdminOrTeacher
+        // Student tries forbidden endpoints
+        var r1 = await _client.GetAsync(MappingRoutes.ListStudents(teacher.UserId));
+        r1.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var r2 = await _client.PostAsync(MappingRoutes.Assign(teacherId, studentId), null);
+        var r2 = await _client.PostAsync(MappingRoutes.Assign(teacher.UserId, anotherStudent.UserId), null);
         r2.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var r3 = await _client.DeleteAsync(MappingRoutes.Unassign(teacherId, studentId));
+        var r3 = await _client.DeleteAsync(MappingRoutes.Unassign(teacher.UserId, anotherStudent.UserId));
         r3.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        var r4 = await _client.GetAsync(MappingRoutes.ListTeachers(studentId));
-        r4.StatusCode.Should().Be(HttpStatusCode.Forbidden); // AdminOnly
-
-        // Cleanup with Admin
-        _users.UseBearer(adminToken);
-        await _users.CleanupUser(studentId);
-        await _users.CleanupUser(teacherId);
-        await _users.CleanupUser(s.UserId);
+        var r4 = await _client.GetAsync(MappingRoutes.ListTeachers(anotherStudent.UserId));
+        r4.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
     [Fact(DisplayName = "Admin can list teachers for a given student")]
     public async Task Admin_List_Teachers_For_Student()
     {
-        // Create teacher + student
-        var teacherId = await _users.CreateUserAsync(Role.Teacher);
-        var studentId = await _users.CreateUserAsync(Role.Student);
+        // Login as Admin (active actor)
+        await _perUser.CreateAndLoginAsync(Role.Admin);
 
-        // Assign
-        var assign = await _client.PostAsync(MappingRoutes.Assign(teacherId, studentId), null);
+        // Create Teacher + Student via Admin token
+        var teacher = TestDataHelper.CreateUser(role: "teacher");
+        var student = TestDataHelper.CreateUser(role: "student");
+
+        (await _client.PostAsJsonAsync(UserRoutes.UserBase, teacher)).EnsureSuccessStatusCode();
+        (await _client.PostAsJsonAsync(UserRoutes.UserBase, student)).EnsureSuccessStatusCode();
+
+        // Assign teacher → student
+        var assign = await _client.PostAsync(MappingRoutes.Assign(teacher.UserId, student.UserId), null);
         assign.StatusCode.Should().Be(HttpStatusCode.OK);
 
         // Admin lists teachers for the student
-        var list = await _client.GetAsync(MappingRoutes.ListTeachers(studentId));
+        var list = await _client.GetAsync(MappingRoutes.ListTeachers(student.UserId));
         list.StatusCode.Should().Be(HttpStatusCode.OK);
         var teachers = await list.Content.ReadFromJsonAsync<List<UserData>>() ?? new();
-        teachers.Should().Contain(t => t.UserId == teacherId);
-
-        // Cleanup
-        await _client.DeleteAsync(MappingRoutes.Unassign(teacherId, studentId));
-        await _users.CleanupUser(studentId);
-        await _users.CleanupUser(teacherId);
+        teachers.Should().Contain(t => t.UserId == teacher.UserId);
     }
 }


### PR DESCRIPTION
### Design for fixing shared token issue in UsersTestsBase:


**Problem:**
- UsersTestsBase currently depends on SharedTestFixture.
- SharedTestFixture seeds a single test user (Admin) and caches its login token.
- Many user tests run with this cached token even after creating new users.
- Result: role-based authorization checks can return false positives (e.g. a Teacher-created request is actually sent with the Admin’s token).

**Solution:**
1. Keep SharedTestFixture for global needs:
- Provides base HttpClient, seeded Admin user, and SignalR startup.
- Useful for tests that truly need a long-lived Admin session (e.g. system/infra tests).
2. Introduce a PerTestUserFixture (IAsyncLifetime):
- Each test that needs to run as a specific role (Admin, Teacher, Student) gets its own fresh user + token.
- Fixture handles:
  - Creating the user in DB
  - Logging in and retrieving a fresh access token
  - Attaching the Authorization header for that test’s client
- On DisposeAsync, fixture deletes the created user and calls logout to remove refresh sessions.
3. Update UsersTestBase:
- Do not automatically reuse SharedTestFixture’s cached token.
- Provide helper methods like CreateAndLoginUserAsync(role) that leverage PerTestUserFixture so each test has an isolated identity.
- Ensure cleanup happens at the end of each test (handled by the fixture).
4. xUnit Integration:
- SharedTestFixture stays registered under [Collection("Shared test collection")].
- PerTestUserFixture is registered separately under [Collection("Per-test user collection")].
- Tests that need role isolation (e.g. Teacher/Student mappings, cross-role restrictions) should depend on PerTestUserFixture.
- Pure Admin/system tests (that don’t need role switching) can keep using SharedTestFixture.

**Expected Outcome:**
- No more shared token leakage between tests.
- Each test runs with a unique user + token, ensuring accurate role-based checks.
- Database stays clean because every created user is deleted in DisposeAsync.
