### PR TITLE
Migrations problem

### DIFF
--- a/backend/ContainerApp/Accessor/Constants/EfMigrationConstants.cs
+++ b/backend/ContainerApp/Accessor/Constants/EfMigrationConstants.cs
@@ -1,0 +1,20 @@
+﻿namespace Accessor.Constants;
+
+public static class EfMigrationConstants
+{
+    public const string InitialMigrationId = "20250916103944_InitialClean";
+    public const string EfCoreVersion = "9.0.8";
+    public const string AnchorTableName = "Users";
+
+    public const string CheckIfAnchorTableExistsSql = $@"
+        SELECT EXISTS (
+            SELECT FROM information_schema.tables
+            WHERE table_schema = 'public'
+            AND table_name = '{AnchorTableName}'
+        );";
+
+    public const string InsertInitialMigrationSql = @"
+        INSERT INTO ""__EFMigrationsHistory"" (""MigrationId"", ""ProductVersion"")
+        VALUES (@migrationId, @version);
+    ";
+}


### PR DESCRIPTION
- Check if the database already has tables but no migration history.
- If so, it marks the first migration as done to stop EF Core from trying to recreate tables and crashing.