### PR TITLE
ouriel/800/fixing-db-configuration

### DIFF
--- a/backend/ContainerApp/Accessor/Program.cs
+++ b/backend/ContainerApp/Accessor/Program.cs
@@ -92,7 +92,7 @@ builder.Services.AddSingleton(sp =>
     return dataSourceBuilder.Build();
 });
 
-builder.Services.AddDbContext<AccessorDbContext>((sp, options) =>
+builder.Services.AddDbContextPool<AccessorDbContext>((sp, options) =>
 {
     var dataSource = sp.GetRequiredService<Npgsql.NpgsqlDataSource>();
     options.UseNpgsql(dataSource, npgsqlOptions =>

--- a/backend/ContainerApp/Accessor/appsettings.json
+++ b/backend/ContainerApp/Accessor/appsettings.json
@@ -15,7 +15,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "Postgres": "Host=postgres;Port=5432;Database=postgres_db;Username=postgres;Password=postgres;Maximum Pool Size=20;Minimum Pool Size=5;Connection Idle Lifetime=300;Connection Pruning Interval=10"
+    "Postgres": "Host=postgres;Port=5432;Database=postgres_db;Username=postgres;Password=postgres;Maximum Pool Size=50;Minimum Pool Size=5;Connection Idle Lifetime=30;Connection Pruning Interval=10"
   },
   "ServiceBus": {
     "ConnectionString": "Endpoint=sb://sbemulatorns:5672/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"


### PR DESCRIPTION
Updated `AccessorDbContext` registration to use pooled service for better performance. Enhanced PostgreSQL connection setup with dynamic JSON support. Adjusted connection string settings to increase maximum pool size from 20 to 50 and reduced idle lifetime from 300 seconds to 30 seconds.
Closes #800 